### PR TITLE
feat(completions): add just

### DIFF
--- a/completions/just/config.json
+++ b/completions/just/config.json
@@ -1,0 +1,7 @@
+{
+  "language": [
+    "en-US",
+    "zh-CN"
+  ],
+  "hooks": true
+}

--- a/completions/just/hooks.ps1
+++ b/completions/just/hooks.ps1
@@ -1,0 +1,23 @@
+function handleCompletions($completions) {
+    $list = @()
+
+    $input_arr = $PSCompletions.input_arr
+    $filter_input_arr = $PSCompletions.filter_input_arr
+    $last_item = $filter_input_arr[-1]
+
+    function return_recipes {
+        $recipes = just --summary 2>$null | ForEach-Object {
+            $_.Split(' ')
+        }
+        return $recipes
+    }
+
+    if (!$last_item) {
+        $recipes = return_recipes
+        foreach ($recipe in $recipes) {
+            $list += $PSCompletions.return_completion($recipe)
+        }
+    }
+
+    return $list + $completions
+}

--- a/completions/just/language/en-US.json
+++ b/completions/just/language/en-US.json
@@ -1,0 +1,560 @@
+{
+  "meta": {
+    "url": "https://github.com/casey/just",
+    "description": [
+      "just - a command runner."
+    ]
+  },
+  "common_option": [
+    {
+      "name": "--alias-style",
+      "tip": [
+        "U: --alias-style <ALIAS_STYLE>",
+        "Set list command alias display style."
+      ],
+      "next": [
+        {
+          "name": "left"
+        },
+        {
+          "name": "right"
+        },
+        {
+          "name": "separate"
+        }
+      ]
+    },
+    {
+      "name": "--allow-missing",
+      "tip": [
+        "Ignore missing recipe and module errors."
+      ]
+    },
+    {
+      "name": "--ceiling",
+      "tip": [
+        "U: --ceiling <CEILING>",
+        "Do not ascend above this directory when searching for a justfile."
+      ],
+      "next": 0
+    },
+    {
+      "name": "--changelog",
+      "tip": [
+        "Print changelog."
+      ]
+    },
+    {
+      "name": "--check",
+      "tip": [
+        "Run --fmt in check mode."
+      ]
+    },
+    {
+      "name": "--choose",
+      "tip": [
+        "Select one or more recipes using a chooser."
+      ]
+    },
+    {
+      "name": "--chooser",
+      "tip": [
+        "U: --chooser <CHOOSER>",
+        "Override binary invoked by --choose."
+      ],
+      "next": 0
+    },
+    {
+      "name": "--clear-shell-args",
+      "tip": [
+        "Clear shell arguments."
+      ]
+    },
+    {
+      "name": "--color",
+      "tip": [
+        "U: --color <COLOR>",
+        "Print colorful output."
+      ],
+      "next": [
+        {
+          "name": "always"
+        },
+        {
+          "name": "auto"
+        },
+        {
+          "name": "never"
+        }
+      ]
+    },
+    {
+      "name": "--command",
+      "alias": [
+        "-c"
+      ],
+      "tip": [
+        "U: -c, --command <COMMAND>...",
+        "Run an arbitrary command with just environment set."
+      ],
+      "next": 0
+    },
+    {
+      "name": "--command-color",
+      "tip": [
+        "U: --command-color <COMMAND_COLOR>",
+        "Echo recipe lines in this color."
+      ],
+      "next": [
+        {
+          "name": "black"
+        },
+        {
+          "name": "blue"
+        },
+        {
+          "name": "cyan"
+        },
+        {
+          "name": "green"
+        },
+        {
+          "name": "purple"
+        },
+        {
+          "name": "red"
+        },
+        {
+          "name": "yellow"
+        }
+      ]
+    },
+    {
+      "name": "--complete-aliases",
+      "tip": [
+        "Auto-complete recipe aliases."
+      ]
+    },
+    {
+      "name": "--completions",
+      "tip": [
+        "U: --completions <SHELL>",
+        "Print shell completion script."
+      ],
+      "next": [
+        {
+          "name": "bash"
+        },
+        {
+          "name": "elvish"
+        },
+        {
+          "name": "fish"
+        },
+        {
+          "name": "nushell"
+        },
+        {
+          "name": "powershell"
+        },
+        {
+          "name": "zsh"
+        }
+      ]
+    },
+    {
+      "name": "--cygpath",
+      "tip": [
+        "U: --cygpath <CYGPATH>",
+        "Use binary to convert between Unix and Windows paths."
+      ],
+      "next": 0
+    },
+    {
+      "name": "--dotenv-filename",
+      "tip": [
+        "U: --dotenv-filename <DOTENV-FILENAME>",
+        "Search for environment file with this name."
+      ],
+      "next": 0
+    },
+    {
+      "name": "--dotenv-path",
+      "alias": [
+        "-E"
+      ],
+      "tip": [
+        "U: -E, --dotenv-path <DOTENV-PATH>",
+        "Load this environment file."
+      ],
+      "next": 0
+    },
+    {
+      "name": "--dry-run",
+      "alias": [
+        "-n"
+      ],
+      "tip": [
+        "Print what just would do without doing it."
+      ]
+    },
+    {
+      "name": "--dump",
+      "tip": [
+        "Print justfile."
+      ]
+    },
+    {
+      "name": "--dump-format",
+      "tip": [
+        "U: --dump-format <FORMAT>",
+        "Set dump format."
+      ],
+      "next": [
+        {
+          "name": "json"
+        },
+        {
+          "name": "just"
+        }
+      ]
+    },
+    {
+      "name": "--edit",
+      "alias": [
+        "-e"
+      ],
+      "tip": [
+        "Edit justfile with editor."
+      ]
+    },
+    {
+      "name": "--evaluate",
+      "tip": [
+        "Evaluate and print all variables."
+      ]
+    },
+    {
+      "name": "--evaluate-format",
+      "tip": [
+        "U: --evaluate-format <FORMAT>",
+        "Set evaluate output format."
+      ],
+      "next": [
+        {
+          "name": "just"
+        },
+        {
+          "name": "shell"
+        }
+      ]
+    },
+    {
+      "name": "--explain",
+      "tip": [
+        "Print recipe doc comment before running it."
+      ]
+    },
+    {
+      "name": "--fmt",
+      "tip": [
+        "Format and overwrite justfile."
+      ]
+    },
+    {
+      "name": "--global-justfile",
+      "alias": [
+        "-g"
+      ],
+      "tip": [
+        "Use global justfile."
+      ]
+    },
+    {
+      "name": "--group",
+      "tip": [
+        "U: --group <GROUP>",
+        "Only list recipes in this group."
+      ],
+      "next": 0
+    },
+    {
+      "name": "--groups",
+      "tip": [
+        "List recipe groups."
+      ]
+    },
+    {
+      "name": "--help",
+      "alias": [
+        "-h"
+      ],
+      "tip": [
+        "Print help."
+      ]
+    },
+    {
+      "name": "--highlight",
+      "tip": [
+        "Highlight echoed recipe lines in bold."
+      ]
+    },
+    {
+      "name": "--indentation",
+      "tip": [
+        "U: --indentation <INDENTATION>",
+        "Indent recipe bodies with this string."
+      ],
+      "next": 0
+    },
+    {
+      "name": "--init",
+      "tip": [
+        "Initialize new justfile in project root."
+      ]
+    },
+    {
+      "name": "--json",
+      "tip": [
+        "Print justfile as JSON."
+      ]
+    },
+    {
+      "name": "--justfile",
+      "alias": [
+        "-f"
+      ],
+      "tip": [
+        "U: -f, --justfile <JUSTFILE>",
+        "Use this justfile."
+      ],
+      "next": 0
+    },
+    {
+      "name": "--justfile-name",
+      "tip": [
+        "U: --justfile-name <NAME>",
+        "Search for justfile with this name."
+      ],
+      "next": 0
+    },
+    {
+      "name": "--list",
+      "alias": [
+        "-l"
+      ],
+      "tip": [
+        "U: -l, --list [<MODULE>...]",
+        "List available recipes."
+      ]
+    },
+    {
+      "name": "--list-heading",
+      "tip": [
+        "U: --list-heading <TEXT>",
+        "Print text before list."
+      ],
+      "next": 0
+    },
+    {
+      "name": "--list-prefix",
+      "tip": [
+        "U: --list-prefix <TEXT>",
+        "Print text before each list item."
+      ],
+      "next": 0
+    },
+    {
+      "name": "--list-submodules",
+      "tip": [
+        "List recipes in submodules."
+      ]
+    },
+    {
+      "name": "--man",
+      "tip": [
+        "Print man page."
+      ]
+    },
+    {
+      "name": "--no-aliases",
+      "tip": [
+        "Do not show aliases in list."
+      ]
+    },
+    {
+      "name": "--no-deps",
+      "tip": [
+        "Do not run recipe dependencies."
+      ]
+    },
+    {
+      "name": "--no-dotenv",
+      "tip": [
+        "Do not load .env file."
+      ]
+    },
+    {
+      "name": "--no-highlight",
+      "tip": [
+        "Do not highlight echoed recipe lines in bold."
+      ]
+    },
+    {
+      "name": "--one",
+      "tip": [
+        "Forbid multiple recipes from being invoked."
+      ]
+    },
+    {
+      "name": "--quiet",
+      "alias": [
+        "-q"
+      ],
+      "tip": [
+        "Suppress all output."
+      ]
+    },
+    {
+      "name": "--set",
+      "tip": [
+        "U: --set <VARIABLE> <VALUE>",
+        "Override variable with value."
+      ],
+      "next": 0
+    },
+    {
+      "name": "--shell",
+      "tip": [
+        "U: --shell <SHELL>",
+        "Invoke shell to run recipes."
+      ],
+      "next": 0
+    },
+    {
+      "name": "--shell-arg",
+      "tip": [
+        "U: --shell-arg <SHELL_ARG>",
+        "Invoke shell with this argument."
+      ],
+      "next": 0
+    },
+    {
+      "name": "--shell-command",
+      "tip": [
+        "Invoke command with the shell used to run recipe lines."
+      ]
+    },
+    {
+      "name": "--show",
+      "alias": [
+        "-s"
+      ],
+      "tip": [
+        "U: -s, --show <PATH>...",
+        "Show recipe at path."
+      ],
+      "repeat": true,
+      "next": []
+    },
+    {
+      "name": "--summary",
+      "tip": [
+        "List names of available recipes."
+      ]
+    },
+    {
+      "name": "--tempdir",
+      "tip": [
+        "U: --tempdir <TEMPDIR>",
+        "Save temporary files to this directory."
+      ],
+      "next": 0
+    },
+    {
+      "name": "--time",
+      "tip": [
+        "Print recipe execution time."
+      ]
+    },
+    {
+      "name": "--timestamp",
+      "tip": [
+        "Print recipe command timestamps."
+      ]
+    },
+    {
+      "name": "--timestamp-format",
+      "tip": [
+        "U: --timestamp-format <TIMESTAMP_FORMAT>",
+        "Timestamp format string."
+      ],
+      "next": 0
+    },
+    {
+      "name": "--unsorted",
+      "alias": [
+        "-u"
+      ],
+      "tip": [
+        "Return list and summary entries in source order."
+      ]
+    },
+    {
+      "name": "--unstable",
+      "tip": [
+        "Enable unstable features."
+      ]
+    },
+    {
+      "name": "--usage",
+      "tip": [
+        "U: --usage <PATH>...",
+        "Print recipe usage information."
+      ],
+      "repeat": true,
+      "next": []
+    },
+    {
+      "name": "--variables",
+      "tip": [
+        "List names of variables."
+      ]
+    },
+    {
+      "name": "--verbose",
+      "alias": [
+        "-v"
+      ],
+      "tip": [
+        "Use verbose output."
+      ]
+    },
+    {
+      "name": "--version",
+      "alias": [
+        "-V"
+      ],
+      "tip": [
+        "Print version."
+      ]
+    },
+    {
+      "name": "--working-directory",
+      "alias": [
+        "-d"
+      ],
+      "tip": [
+        "U: -d, --working-directory <WORKING-DIRECTORY>",
+        "Use this working directory."
+      ],
+      "next": 0
+    },
+    {
+      "name": "--yes",
+      "tip": [
+        "Automatically confirm all recipes."
+      ]
+    }
+  ]
+}

--- a/completions/just/language/zh-CN.json
+++ b/completions/just/language/zh-CN.json
@@ -1,0 +1,560 @@
+{
+  "meta": {
+    "url": "https://github.com/casey/just",
+    "description": [
+      "just - 一个命令运行器。"
+    ]
+  },
+  "common_option": [
+    {
+      "name": "--alias-style",
+      "tip": [
+        "U: --alias-style <ALIAS_STYLE>",
+        "设置列表命令的别名显示样式。"
+      ],
+      "next": [
+        {
+          "name": "left"
+        },
+        {
+          "name": "right"
+        },
+        {
+          "name": "separate"
+        }
+      ]
+    },
+    {
+      "name": "--allow-missing",
+      "tip": [
+        "忽略缺失的 recipe 和模块错误。"
+      ]
+    },
+    {
+      "name": "--ceiling",
+      "tip": [
+        "U: --ceiling <CEILING>",
+        "搜索 justfile 时不要向上超过此目录。"
+      ],
+      "next": 0
+    },
+    {
+      "name": "--changelog",
+      "tip": [
+        "打印变更日志。"
+      ]
+    },
+    {
+      "name": "--check",
+      "tip": [
+        "以检查模式运行 --fmt。"
+      ]
+    },
+    {
+      "name": "--choose",
+      "tip": [
+        "使用选择器选择一个或多个 recipe。"
+      ]
+    },
+    {
+      "name": "--chooser",
+      "tip": [
+        "U: --chooser <CHOOSER>",
+        "覆盖 --choose 调用的二进制程序。"
+      ],
+      "next": 0
+    },
+    {
+      "name": "--clear-shell-args",
+      "tip": [
+        "清除 shell 参数。"
+      ]
+    },
+    {
+      "name": "--color",
+      "tip": [
+        "U: --color <COLOR>",
+        "输出彩色内容。"
+      ],
+      "next": [
+        {
+          "name": "always"
+        },
+        {
+          "name": "auto"
+        },
+        {
+          "name": "never"
+        }
+      ]
+    },
+    {
+      "name": "--command",
+      "alias": [
+        "-c"
+      ],
+      "tip": [
+        "U: -c, --command <COMMAND>...",
+        "在 just 环境中运行任意命令。"
+      ],
+      "next": 0
+    },
+    {
+      "name": "--command-color",
+      "tip": [
+        "U: --command-color <COMMAND_COLOR>",
+        "使用指定颜色回显 recipe 命令行。"
+      ],
+      "next": [
+        {
+          "name": "black"
+        },
+        {
+          "name": "blue"
+        },
+        {
+          "name": "cyan"
+        },
+        {
+          "name": "green"
+        },
+        {
+          "name": "purple"
+        },
+        {
+          "name": "red"
+        },
+        {
+          "name": "yellow"
+        }
+      ]
+    },
+    {
+      "name": "--complete-aliases",
+      "tip": [
+        "自动补全 recipe 别名。"
+      ]
+    },
+    {
+      "name": "--completions",
+      "tip": [
+        "U: --completions <SHELL>",
+        "打印 shell 补全脚本。"
+      ],
+      "next": [
+        {
+          "name": "bash"
+        },
+        {
+          "name": "elvish"
+        },
+        {
+          "name": "fish"
+        },
+        {
+          "name": "nushell"
+        },
+        {
+          "name": "powershell"
+        },
+        {
+          "name": "zsh"
+        }
+      ]
+    },
+    {
+      "name": "--cygpath",
+      "tip": [
+        "U: --cygpath <CYGPATH>",
+        "使用指定程序转换 Unix 和 Windows 路径。"
+      ],
+      "next": 0
+    },
+    {
+      "name": "--dotenv-filename",
+      "tip": [
+        "U: --dotenv-filename <DOTENV-FILENAME>",
+        "搜索指定名称的环境文件。"
+      ],
+      "next": 0
+    },
+    {
+      "name": "--dotenv-path",
+      "alias": [
+        "-E"
+      ],
+      "tip": [
+        "U: -E, --dotenv-path <DOTENV-PATH>",
+        "加载指定环境文件。"
+      ],
+      "next": 0
+    },
+    {
+      "name": "--dry-run",
+      "alias": [
+        "-n"
+      ],
+      "tip": [
+        "打印 just 将执行的内容但不实际运行。"
+      ]
+    },
+    {
+      "name": "--dump",
+      "tip": [
+        "打印 justfile。"
+      ]
+    },
+    {
+      "name": "--dump-format",
+      "tip": [
+        "U: --dump-format <FORMAT>",
+        "设置 dump 输出格式。"
+      ],
+      "next": [
+        {
+          "name": "json"
+        },
+        {
+          "name": "just"
+        }
+      ]
+    },
+    {
+      "name": "--edit",
+      "alias": [
+        "-e"
+      ],
+      "tip": [
+        "用编辑器打开 justfile。"
+      ]
+    },
+    {
+      "name": "--evaluate",
+      "tip": [
+        "求值并打印所有变量。"
+      ]
+    },
+    {
+      "name": "--evaluate-format",
+      "tip": [
+        "U: --evaluate-format <FORMAT>",
+        "设置 evaluate 输出格式。"
+      ],
+      "next": [
+        {
+          "name": "just"
+        },
+        {
+          "name": "shell"
+        }
+      ]
+    },
+    {
+      "name": "--explain",
+      "tip": [
+        "运行前打印 recipe 文档注释。"
+      ]
+    },
+    {
+      "name": "--fmt",
+      "tip": [
+        "格式化并覆盖 justfile。"
+      ]
+    },
+    {
+      "name": "--global-justfile",
+      "alias": [
+        "-g"
+      ],
+      "tip": [
+        "使用全局 justfile。"
+      ]
+    },
+    {
+      "name": "--group",
+      "tip": [
+        "U: --group <GROUP>",
+        "只列出指定分组中的 recipes。"
+      ],
+      "next": 0
+    },
+    {
+      "name": "--groups",
+      "tip": [
+        "列出 recipe 分组。"
+      ]
+    },
+    {
+      "name": "--help",
+      "alias": [
+        "-h"
+      ],
+      "tip": [
+        "打印帮助。"
+      ]
+    },
+    {
+      "name": "--highlight",
+      "tip": [
+        "以粗体高亮回显的 recipe 命令行。"
+      ]
+    },
+    {
+      "name": "--indentation",
+      "tip": [
+        "U: --indentation <INDENTATION>",
+        "使用指定字符串缩进 recipe 主体。"
+      ],
+      "next": 0
+    },
+    {
+      "name": "--init",
+      "tip": [
+        "在项目根目录初始化新的 justfile。"
+      ]
+    },
+    {
+      "name": "--json",
+      "tip": [
+        "以 JSON 格式打印 justfile。"
+      ]
+    },
+    {
+      "name": "--justfile",
+      "alias": [
+        "-f"
+      ],
+      "tip": [
+        "U: -f, --justfile <JUSTFILE>",
+        "使用指定 justfile。"
+      ],
+      "next": 0
+    },
+    {
+      "name": "--justfile-name",
+      "tip": [
+        "U: --justfile-name <NAME>",
+        "搜索指定名称的 justfile。"
+      ],
+      "next": 0
+    },
+    {
+      "name": "--list",
+      "alias": [
+        "-l"
+      ],
+      "tip": [
+        "U: -l, --list [<MODULE>...]",
+        "列出可用 recipes。"
+      ]
+    },
+    {
+      "name": "--list-heading",
+      "tip": [
+        "U: --list-heading <TEXT>",
+        "在列表前打印指定文本。"
+      ],
+      "next": 0
+    },
+    {
+      "name": "--list-prefix",
+      "tip": [
+        "U: --list-prefix <TEXT>",
+        "在每个列表项前打印指定文本。"
+      ],
+      "next": 0
+    },
+    {
+      "name": "--list-submodules",
+      "tip": [
+        "列出子模块中的 recipes。"
+      ]
+    },
+    {
+      "name": "--man",
+      "tip": [
+        "打印 man page。"
+      ]
+    },
+    {
+      "name": "--no-aliases",
+      "tip": [
+        "列表中不显示别名。"
+      ]
+    },
+    {
+      "name": "--no-deps",
+      "tip": [
+        "不运行 recipe 依赖。"
+      ]
+    },
+    {
+      "name": "--no-dotenv",
+      "tip": [
+        "不加载 .env 文件。"
+      ]
+    },
+    {
+      "name": "--no-highlight",
+      "tip": [
+        "不高亮回显的 recipe 命令行。"
+      ]
+    },
+    {
+      "name": "--one",
+      "tip": [
+        "禁止一次调用多个 recipes。"
+      ]
+    },
+    {
+      "name": "--quiet",
+      "alias": [
+        "-q"
+      ],
+      "tip": [
+        "抑制所有输出。"
+      ]
+    },
+    {
+      "name": "--set",
+      "tip": [
+        "U: --set <VARIABLE> <VALUE>",
+        "用指定值覆盖变量。"
+      ],
+      "next": 0
+    },
+    {
+      "name": "--shell",
+      "tip": [
+        "U: --shell <SHELL>",
+        "调用指定 shell 运行 recipes。"
+      ],
+      "next": 0
+    },
+    {
+      "name": "--shell-arg",
+      "tip": [
+        "U: --shell-arg <SHELL_ARG>",
+        "调用 shell 时传入指定参数。"
+      ],
+      "next": 0
+    },
+    {
+      "name": "--shell-command",
+      "tip": [
+        "使用运行 recipe 行的 shell 调用命令。"
+      ]
+    },
+    {
+      "name": "--show",
+      "alias": [
+        "-s"
+      ],
+      "tip": [
+        "U: -s, --show <PATH>...",
+        "显示指定 recipe。"
+      ],
+      "repeat": true,
+      "next": []
+    },
+    {
+      "name": "--summary",
+      "tip": [
+        "列出可用 recipe 名称。"
+      ]
+    },
+    {
+      "name": "--tempdir",
+      "tip": [
+        "U: --tempdir <TEMPDIR>",
+        "将临时文件保存到指定目录。"
+      ],
+      "next": 0
+    },
+    {
+      "name": "--time",
+      "tip": [
+        "打印 recipe 执行时间。"
+      ]
+    },
+    {
+      "name": "--timestamp",
+      "tip": [
+        "打印 recipe 命令时间戳。"
+      ]
+    },
+    {
+      "name": "--timestamp-format",
+      "tip": [
+        "U: --timestamp-format <TIMESTAMP_FORMAT>",
+        "时间戳格式字符串。"
+      ],
+      "next": 0
+    },
+    {
+      "name": "--unsorted",
+      "alias": [
+        "-u"
+      ],
+      "tip": [
+        "按源码顺序返回 list 和 summary 条目。"
+      ]
+    },
+    {
+      "name": "--unstable",
+      "tip": [
+        "启用不稳定功能。"
+      ]
+    },
+    {
+      "name": "--usage",
+      "tip": [
+        "U: --usage <PATH>...",
+        "打印 recipe 用法信息。"
+      ],
+      "repeat": true,
+      "next": []
+    },
+    {
+      "name": "--variables",
+      "tip": [
+        "列出变量名称。"
+      ]
+    },
+    {
+      "name": "--verbose",
+      "alias": [
+        "-v"
+      ],
+      "tip": [
+        "使用详细输出。"
+      ]
+    },
+    {
+      "name": "--version",
+      "alias": [
+        "-V"
+      ],
+      "tip": [
+        "打印版本。"
+      ]
+    },
+    {
+      "name": "--working-directory",
+      "alias": [
+        "-d"
+      ],
+      "tip": [
+        "U: -d, --working-directory <WORKING-DIRECTORY>",
+        "使用指定工作目录。"
+      ],
+      "next": 0
+    },
+    {
+      "name": "--yes",
+      "tip": [
+        "自动确认所有 recipes。"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- [x] [_Contributing Guide_](https://pscompletions.abgox.com/docs/contributing/)

- 根据 `just --help` 的结果写了英文版的补全，中文版由 Codex 翻译得到
- 添加了一个 hook，可以根据 `just --summary` 的结果动态生成补全

另外我遇到了一个问题，但不知道是不是我配置有误。我无法在输入 `just --` 后按下 tab 获得补全，但我看 ffmpeg #139 的 `config.json` 也是这么写的，我就没有修改，虽然我同样无法在输入 `ffmpeg --` 后按下 tab 获得补全。如果这个问题确定是 Bug 的话，我再单开一个 issue

同时 just 是有官方 powershell 补全的，运行 `$env:JUST_COMPLETE = "powershell"; just` 就可以看到补全内容，但我没有参考这个实现（