### PR TITLE
添加两个配置项，使补全菜单在过滤无匹配时可自动退出，释放键盘输入，让用户可以自由输入不在补全列表中的内容

### DIFF
--- a/completions/psc/language/en-US.json
+++ b/completions/psc/language/en-US.json
@@ -479,6 +479,26 @@
               ]
             },
             {
+              "name": "enable_filter_subsequence_match",
+              "tip": [
+                "Current Value: {{ $PSCompletions.config.enable_filter_subsequence_match }} (Default: 0)",
+                "Enable sequential subsequence matching.",
+                "When enabled, typing 'cp' matches 'cherry-pick'.",
+                "Characters don't need to be contiguous - they just need to appear in order."
+              ],
+              "next": [
+                {
+                  "name": "0",
+                  "tip": [
+                    "Default value."
+                  ]
+                },
+                {
+                  "name": "1"
+                }
+              ]
+            },
+            {
               "name": "enable_hooks_tip",
               "tip": [
                 "Current Value: {{ $PSCompletions.config.enable_hooks_tip }} (Default: 1)",

--- a/completions/psc/language/en-US.json
+++ b/completions/psc/language/en-US.json
@@ -452,6 +452,33 @@
               ]
             },
             {
+              "name": "enable_filter_exit_on_nomatch",
+              "tip": [
+                "Current Value: {{ $PSCompletions.config.enable_filter_exit_on_nomatch }} (Default: 1)",
+                "When no completion matches the filter, close the menu and let the user type freely.",
+                "When disabled, it keeps the menu open and reverts to the previous filter state."
+              ],
+              "next": [
+                {
+                  "name": "0"
+                },
+                {
+                  "name": "1",
+                  "tip": [
+                    "Default value."
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "filter_exit_nomatch_threshold",
+              "tip": [
+                "Current Value: {{ $PSCompletions.config.filter_exit_nomatch_threshold }} (Default: 2)",
+                "How many consecutive non-matching characters to tolerate before closing the menu.",
+                "Used together with enable_filter_exit_on_nomatch."
+              ]
+            },
+            {
               "name": "enable_hooks_tip",
               "tip": [
                 "Current Value: {{ $PSCompletions.config.enable_hooks_tip }} (Default: 1)",

--- a/completions/psc/language/zh-CN.json
+++ b/completions/psc/language/zh-CN.json
@@ -451,6 +451,33 @@
               ]
             },
             {
+              "name": "enable_filter_exit_on_nomatch",
+              "tip": [
+                "当前值: {{ $PSCompletions.config.enable_filter_exit_on_nomatch }} (默认值: 1)",
+                "当过滤无匹配项时自动关闭补全菜单，让用户自由输入。",
+                "禁用后，无匹配项时将保持菜单打开并回退到上一过滤结果。"
+              ],
+              "next": [
+                {
+                  "name": "0"
+                },
+                {
+                  "name": "1",
+                  "tip": [
+                    "默认值"
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "filter_exit_nomatch_threshold",
+              "tip": [
+                "当前值: {{ $PSCompletions.config.filter_exit_nomatch_threshold }} (默认值: 2)",
+                "连续输入多少个不属于补全列表的字符后关闭补全菜单。",
+                "可以与 enable_filter_exit_on_nomatch 配合使用。"
+              ]
+            },
+            {
               "name": "enable_hooks_tip",
               "tip": [
                 "当前值: {{ $PSCompletions.config.enable_hooks_tip }} (默认值: 1)",

--- a/completions/psc/language/zh-CN.json
+++ b/completions/psc/language/zh-CN.json
@@ -478,6 +478,26 @@
               ]
             },
             {
+              "name": "enable_filter_subsequence_match",
+              "tip": [
+                "当前值: {{ $PSCompletions.config.enable_filter_subsequence_match }} (默认值: 0)",
+                "启用顺序子串匹配模式。",
+                "开启后，输入 'cp' 可以匹配 'cherry-pick'",
+                "输入字符无需连续，按顺序出现在补全项文本中即可匹配。"
+              ],
+              "next": [
+                {
+                  "name": "0",
+                  "tip": [
+                    "默认值"
+                  ]
+                },
+                {
+                  "name": "1"
+                }
+              ]
+            },
+            {
               "name": "enable_hooks_tip",
               "tip": [
                 "当前值: {{ $PSCompletions.config.enable_hooks_tip }} (默认值: 1)",

--- a/module/PSCompletions/PSCompletions.ps1
+++ b/module/PSCompletions/PSCompletions.ps1
@@ -198,7 +198,7 @@ New-Variable -Name PSCompletions -Option Constant -Value @{
             color_item  = @('item_color', 'filter_color', 'border_color', 'status_color', 'tip_color', 'selected_color', 'selected_bgcolor')
             color_value = @('White', 'Black', 'Gray', 'DarkGray', 'Red', 'DarkRed', 'Green', 'DarkGreen', 'Blue', 'DarkBlue', 'Cyan', 'DarkCyan', 'Yellow', 'DarkYellow', 'Magenta', 'DarkMagenta')
             config_item = @(
-                'trigger_key', 'between_item_and_symbol', 'status_symbol', 'filter_symbol', 'completion_suffix', 'enable_menu', 'enable_menu_enhance', 'enable_menu_show_below', 'enable_tip', 'enable_hooks_tip', 'enable_tip_when_enhance', 'enable_completions_sort', 'enable_tip_follow_cursor', 'enable_list_follow_cursor', 'enable_path_with_trailing_separator', 'enable_list_loop', 'enable_enter_when_single', 'enable_list_full_width', 'list_min_width', 'list_max_count_when_above', 'list_max_count_when_below', 'height_from_menu_bottom_to_cursor_when_above', 'height_from_menu_top_to_cursor_when_below', 'completions_confirm_limit'
+                'trigger_key', 'between_item_and_symbol', 'status_symbol', 'filter_symbol', 'completion_suffix', 'enable_menu', 'enable_menu_enhance', 'enable_menu_show_below', 'enable_tip', 'enable_hooks_tip', 'enable_tip_when_enhance', 'enable_completions_sort', 'enable_tip_follow_cursor', 'enable_list_follow_cursor', 'enable_path_with_trailing_separator', 'enable_list_loop', 'enable_enter_when_single', 'enable_list_full_width', 'enable_filter_exit_on_nomatch', 'filter_exit_nomatch_threshold', 'list_min_width', 'list_max_count_when_above', 'list_max_count_when_below', 'height_from_menu_bottom_to_cursor_when_above', 'height_from_menu_top_to_cursor_when_below', 'completions_confirm_limit'
             )
         }
     }
@@ -248,6 +248,8 @@ New-Variable -Name PSCompletions -Option Constant -Value @{
         enable_enter_when_single                     = 0
         enable_list_loop                             = 1
         enable_list_full_width                       = 1
+        enable_filter_exit_on_nomatch                = 1
+        filter_exit_nomatch_threshold                = 2
         enable_list_follow_cursor                    = 1
 
         enable_tip                                   = 1
@@ -1957,6 +1959,8 @@ Refer to: https://pscompletions.abgox.com/docs/require-admin
 
         $menu.offset = 0  # 索引的偏移量，用于滚动翻页
 
+        $menu.nomatch_count = 0  # 连续无匹配的字符计数
+
         # 记录每一次过滤的数据
         $menu.data = [System.Collections.Generic.List[System.Object]]::new()
 
@@ -2076,8 +2080,25 @@ Refer to: https://pscompletions.abgox.com/docs/require-admin
                     ''
                     break loop
                 }
-                { $_ -in @(32, 13) } {
+                { $_ -eq 32 } {
                     # 32: Space
+                    if ($config.enable_filter_exit_on_nomatch) {
+                        # 退出菜单，将已输入文本（或空格）插入命令行
+                        $typedText = $menu.filter
+                        $menu.reset_menu()
+                        if ($typedText) {
+                            [Microsoft.PowerShell.PSConsoleReadLine]::Insert($typedText + ' ')
+                        }
+                        else {
+                            [Microsoft.PowerShell.PSConsoleReadLine]::Insert(' ')
+                        }
+                        break loop
+                    }
+                    $menu.handle_menu_output($menu.filter_list[$menu.selected_index])
+                    $menu.reset_menu()
+                    break loop
+                }
+                { $_ -eq 13 } {
                     # 13: Enter
                     $menu.handle_menu_output($menu.filter_list[$menu.selected_index])
                     $menu.reset_menu()
@@ -2128,6 +2149,7 @@ Refer to: https://pscompletions.abgox.com/docs/require-admin
                         }
 
                         $menu.handle_menu_data('get')
+                        $menu.nomatch_count = 0
                     }
                     else {
                         # add
@@ -2159,10 +2181,31 @@ Refer to: https://pscompletions.abgox.com/docs/require-admin
                         $menu.filter_list = $resultList.ToArray()
 
                         if (!$menu.filter_list) {
+                            $typedText = $menu.filter
                             $menu.filter = $menu.data[-1].filter
                             $menu.filter_list = $menu.data[-1].filter_list
+                            if ($config.enable_filter_exit_on_nomatch) {
+                                $menu.nomatch_count++
+                                if ($menu.nomatch_count -ge $config.filter_exit_nomatch_threshold) {
+                                    $menu.reset_menu()
+                                    [Microsoft.PowerShell.PSConsoleReadLine]::Insert($typedText)
+                                    break loop
+                                }
+                                # 未达阈值：显示已输入的完整文本，但保持补全列表为上一状态
+                                $menu.filter = $typedText
+                                $menu.reset_menu($false)
+                                $menu.parse_menu_list()
+                                $menu.new_menu_border_buffer()
+                                $menu.new_menu_list_buffer($menu.offset)
+                                $menu.new_menu_tip_buffer($menu.selected_index)
+                                $menu.new_menu_status_buffer()
+                                $menu.new_menu_filter_buffer($menu.filter)
+                                $menu.set_menu_selection(0)
+                                $menu.handle_menu_data('add')
+                            }
                         }
                         else {
+                            $menu.nomatch_count = 0
                             $menu.reset_menu($false)
                             $menu.parse_menu_list()
                             $menu.new_menu_border_buffer()

--- a/module/PSCompletions/PSCompletions.ps1
+++ b/module/PSCompletions/PSCompletions.ps1
@@ -198,7 +198,7 @@ New-Variable -Name PSCompletions -Option Constant -Value @{
             color_item  = @('item_color', 'filter_color', 'border_color', 'status_color', 'tip_color', 'selected_color', 'selected_bgcolor')
             color_value = @('White', 'Black', 'Gray', 'DarkGray', 'Red', 'DarkRed', 'Green', 'DarkGreen', 'Blue', 'DarkBlue', 'Cyan', 'DarkCyan', 'Yellow', 'DarkYellow', 'Magenta', 'DarkMagenta')
             config_item = @(
-                'trigger_key', 'between_item_and_symbol', 'status_symbol', 'filter_symbol', 'completion_suffix', 'enable_menu', 'enable_menu_enhance', 'enable_menu_show_below', 'enable_tip', 'enable_hooks_tip', 'enable_tip_when_enhance', 'enable_completions_sort', 'enable_tip_follow_cursor', 'enable_list_follow_cursor', 'enable_path_with_trailing_separator', 'enable_list_loop', 'enable_enter_when_single', 'enable_list_full_width', 'enable_filter_exit_on_nomatch', 'filter_exit_nomatch_threshold', 'list_min_width', 'list_max_count_when_above', 'list_max_count_when_below', 'height_from_menu_bottom_to_cursor_when_above', 'height_from_menu_top_to_cursor_when_below', 'completions_confirm_limit'
+                'trigger_key', 'between_item_and_symbol', 'status_symbol', 'filter_symbol', 'completion_suffix', 'enable_menu', 'enable_menu_enhance', 'enable_menu_show_below', 'enable_tip', 'enable_hooks_tip', 'enable_tip_when_enhance', 'enable_completions_sort', 'enable_tip_follow_cursor', 'enable_list_follow_cursor', 'enable_path_with_trailing_separator', 'enable_list_loop', 'enable_enter_when_single', 'enable_list_full_width', 'enable_filter_exit_on_nomatch', 'filter_exit_nomatch_threshold', 'enable_filter_subsequence_match', 'list_min_width', 'list_max_count_when_above', 'list_max_count_when_below', 'height_from_menu_bottom_to_cursor_when_above', 'height_from_menu_top_to_cursor_when_below', 'completions_confirm_limit'
             )
         }
     }
@@ -250,6 +250,7 @@ New-Variable -Name PSCompletions -Option Constant -Value @{
         enable_list_full_width                       = 1
         enable_filter_exit_on_nomatch                = 1
         filter_exit_nomatch_threshold                = 2
+        enable_filter_subsequence_match              = 0
         enable_list_follow_cursor                    = 1
 
         enable_tip                                   = 1
@@ -2159,7 +2160,14 @@ Refer to: https://pscompletions.abgox.com/docs/require-admin
                         $menu.filter += $PressKey.Character
 
                         $escapedFilter = $menu.filter -replace '(\[|\])', '`$1'
-                        if ($escapedFilter.StartsWith('^')) {
+                        if ($config.enable_filter_subsequence_match) {
+                            $regexPattern = '^' + (($menu.filter.ToCharArray() | ForEach-Object { [regex]::Escape($_) }) -join '.*') + '.*'
+                            $comparison = {
+                                param($text)
+                                $text -match $regexPattern
+                            }
+                        }
+                        elseif ($escapedFilter.StartsWith('^')) {
                             $comparison = {
                                 param($text)
                                 $text -like $escapedFilter.Substring(1) + '*'

--- a/module/PSCompletions/PSCompletions.ps1
+++ b/module/PSCompletions/PSCompletions.ps1
@@ -2174,7 +2174,7 @@ Refer to: https://pscompletions.abgox.com/docs/require-admin
                         $list = $menu.filter_list
                         $resultList = [System.Collections.Generic.List[System.Object]]::new($list.Count)
                         foreach ($f in $list) {
-                            if ($comparison.Invoke($f.ListItemText)) {
+                            if ($comparison.Invoke($f.ListItemText -replace '\x1b\[[\d;]*m', '')) {
                                 $resultList.Add($f)
                             }
                         }


### PR DESCRIPTION
# feat: 新增过滤退出机制、顺序子串匹配 & fix: ANSI 转义导致过滤失效

## 概述

本 PR 包含三项改动：

1. 新增 `enable_filter_exit_on_nomatch` 和 `filter_exit_nomatch_threshold` 配置项，当过滤无匹配时可自动关闭菜单并释放键盘输入。
2. 修复补全项文本包含 ANSI 转义序列时导致过滤失效的问题。
3. 新增顺序子串匹配模式，支持非连续字符的顺序匹配。

---

## 变更内容

### Commit 1: `984d5e2`

**feat: Add enable_filter_exit_on_nomatch and filter_exit_nomatch_threshold**

#### 问题

当按下 Tab 打开模块补全菜单后，所有键盘输入都被菜单捕获用于过滤补全列表。如果用户想输入的内容不在补全列表中，字符会被菜单静默吞掉，无法输入到命令行中。用户必须按 Esc 手动关闭菜单后才能继续输入。

#### 新增配置项

| 配置项                          | 默认值 | 说明                                                |
| ------------------------------- | ------ | --------------------------------------------------- |
| `enable_filter_exit_on_nomatch` | `1`    | 主开关，启用后菜单在过滤无匹配时可根据阈值关闭      |
| `filter_exit_nomatch_threshold` | `2`    | 连续不匹配字符的容忍数量，默认允许连输 2 个错误字符 |

#### 实现方式

1. **配置注册** — 在 `menu.const.config_item` 和 `default_config` 中添加两项配置
2. **菜单状态变量** — 新增 `$menu.nomatch_count = 0` 连续计数
3. **阈值退出机制** — 当 `filter_list` 为空时：
   - **低于阈值**：`nomatch_count` 递增，菜单保持打开，过滤栏显示已输入文本，补全列表保留上一次匹配状态
   - **达到阈值**：调用 `$menu.reset_menu()` 关闭菜单，通过 `[Microsoft.PowerShell.PSConsoleReadLine]::Insert($typedText)` 将已输入文本插入命令行，`break loop`
4. **匹配成功时重置** — `$menu.nomatch_count = 0`
5. **空格键行为变更** — 启用本功能时，空格退出菜单并插入文本（含空格），而非选中菜单项

`module/PSCompletions/PSCompletions.ps1:2183-2203`

```powershell
if (!$menu.filter_list) {
    $typedText = $menu.filter
    $menu.filter = $menu.data[-1].filter
    $menu.filter_list = $menu.data[-1].filter_list
    if ($config.enable_filter_exit_on_nomatch) {
        $menu.nomatch_count++
        if ($menu.nomatch_count -ge $config.filter_exit_nomatch_threshold) {
            $menu.reset_menu()
            [Microsoft.PowerShell.PSConsoleReadLine]::Insert($typedText)
            break loop
        }
        $menu.filter = $typedText
        $menu.reset_menu($false)
        $menu.parse_menu_list()
        $menu.new_menu_border_buffer()
        $menu.new_menu_list_buffer($menu.offset)
    }
}
```

https://github.com/user-attachments/assets/3c869259-717c-4d25-a2e2-5d5caaef7d4c


---

### Commit 2: `191aa5f`

**fix(module): ANSI escape sequences cause filter to break**

#### 问题

部分补全项的 `ListItemText` 包含 ANSI 颜色转义序列（`\x1b[...m`）。

由于过滤逻辑直接基于原始字符串进行匹配，导致以下方式均可能失效：

* 前缀匹配（`^`）
* 子串匹配（`-like`）
* 正则匹配（`-match`）

用户看到的文本虽然正常，但实际字符串以 ANSI 转义字符开头，因此无法正确命中过滤条件。

#### 修复方案

在调用 `$comparison.Invoke()` 前统一移除 ANSI 转义序列，避免在各个匹配实现中重复处理。

`module/PSCompletions/PSCompletions.ps1:2184`

```powershell
foreach ($f in $list) {
    if ($comparison.Invoke($f.ListItemText -replace '\x1b\[[\d;]*m', '')) {
        $resultList.Add($f)
    }
}
```

---

### Commit 3: `e2ab45c`

**feat(module): add subsequence matching support**

#### 新增配置项

```powershell
enable_filter_subsequence_match
```

默认值：

```powershell
0
```

启用后，输入字符无需连续出现，只需按顺序出现在补全项文本中即可匹配。

#### 匹配规则

* 首字符必须匹配补全项文本的起始字符
* 后续字符按顺序出现即可，无需连续
* 匹配不区分大小写

#### 示例

| 输入   | cherry-pick | checkout | commit |
| ------ | ----------- | -------- | ------ |
| `cp` | 匹配        | 不匹配   | 不匹配 |
| `cm` | 不匹配      | 不匹配   | 匹配   |
| `ch` | 匹配        | 匹配     | 不匹配 |
| `co` | 匹配        | 匹配     | 匹配   |

#### 实现方式

在 `module/PSCompletions/PSCompletions.ps1:2163` 增加新的过滤策略：

```powershell
if ($config.enable_filter_subsequence_match) {
    $regexPattern = '^' + (($menu.filter.ToCharArray() | ForEach-Object { [regex]::Escape($_) }) -join '.*') + '.*'

    $comparison = {
        param($text)
        $text -match $regexPattern
    }
}
```

输入：

```text
abc
```

会生成：

```regex
^a.*b.*c.*
```

其中：

* `^` 保证首字符必须匹配文本开头
* `.*` 允许字符之间存在任意内容
* `-match` 默认不区分大小写

---

## 配置方法

开启：

```powershell
psc menu config enable_filter_subsequence_match 1
```

关闭（默认）：

```powershell
psc menu config enable_filter_subsequence_match 0
```

https://github.com/user-attachments/assets/0a3dd998-eb12-4a7b-9dd5-1fa1cc122420


---

## 性能

基于 10,000 次迭代、50 个补全项的测试结果：

| 实现方式             | 结果 |
| -------------------- | ---- |
| `-match`           | 最优 |
| `[regex]::IsMatch` | 略慢 |
| 双指针实现           | 很慢 |

最终采用 `-match` 作为实现方案。

<details>
<summary>性能测试脚本（展开查看）</summary>

```powershell
# 测试顺序子串匹配的三种实现方式的性能
# 1. 双指针手写匹配
# 2. -match 正则匹配
# 3. [regex]::IsMatch 正则匹配

$testCases = @(
    @{ filter = 'cp'; items = 'add','am','annotate','apply','archive','bisect','blame','branch','bundle','cat-file','check-attr','check-ignore','check-mailmap','check-ref-format','checkout','checkout-index','cherry','cherry-pick','citool','clean','clone','commit','config','describe','diff','fetch','format-patch','gc','git','grep','help','init','log','merge','mv','notes','pull','push','rebase','reset','restore','revert','rm','shortlog','show','stash','status','switch','tag' }
    @{ filter = 'c'; items = 'add','am','annotate','apply','archive','bisect','blame','branch','bundle','checkout','cherry-pick','clean','clone','commit','config' }
    @{ filter = 'ch'; items = 'add','am','annotate','apply','archive','bisect','blame','branch','bundle','checkout','cherry-pick','clean','clone','commit','config' }
    @{ filter = 'gst'; items = 'get-service','get-process','get-item','get-childitem','get-content','get-date','get-help','get-history','get-job','get-member','get-module','get-process','get-service','get-variable','get-wmiobject','group-object' }
    @{ filter = 'gt'; items = 'get-service','get-process','get-item','get-childitem','get-content','get-date','get-help','get-history','get-job','get-member','get-module','get-process','get-service','get-variable','get-wmiobject','group-object' }
    @{ filter = 'aaaa'; items = 'add','am','annotate','apply','archive','bisect','blame','branch','bundle','checkout','cherry-pick','clean','clone','commit','config','cherry-pick','checkout-index','check-attr','check-ignore','cat-file' }
)

$warmup = 100
$iterations = 10000

# 双指针匹配（首字母锚定 + 后续顺序子串）
function Test-DoublePointer {
    param([string]$Filter, [string]$Text)
    if ($Text.Length -eq 0) { return $false }
    # 首字母必须匹配文本开头
    $pos = $Text.IndexOf($Filter[0].ToString(), 0, [StringComparison]::OrdinalIgnoreCase)
    if ($pos -ne 0) { return $false }
    # 后续字符按顺序出现即可
    $pos = 1
    for ($i = 1; $i -lt $Filter.Length; $i++) {
        $pos = $Text.IndexOf($Filter[$i].ToString(), $pos, [StringComparison]::OrdinalIgnoreCase)
        if ($pos -lt 0) { return $false }
        $pos++
    }
    return $true
}

Write-Host "===== 性能对比测试 =====" -ForegroundColor Cyan
Write-Host "预热 $warmup 次，正式测试 $iterations 次`n" -ForegroundColor DarkGray

foreach ($tc in $testCases) {
    $filter = $tc.filter
    $items = $tc.items
    $escapedFilter = $filter -replace '(\[|\])', '`$1'

    # 正则模式（当前实现）
    $regexPattern = '^' + (($filter.ToCharArray() | ForEach-Object { [regex]::Escape($_) }) -join '.*') + '.*'

    Write-Host "--- filter='$filter', items=$($items.Count) ---" -ForegroundColor Yellow

    # ---- 预热 ----
    1..$warmup | ForEach-Object {
        foreach ($item in $items) {
            $null = $item -match $regexPattern
            $null = [regex]::IsMatch($item, $regexPattern, 'IgnoreCase')
            $null = Test-DoublePointer -Filter $filter -Text $item
        }
    }

    # ---- 测试 -match 正则 ----
    $sw = [System.Diagnostics.Stopwatch]::StartNew()
    1..$iterations | ForEach-Object {
        foreach ($item in $items) {
            $null = $item -match $regexPattern
        }
    }
    $sw.Stop()
    $matchTime = $sw.ElapsedMilliseconds

    # ---- 测试 [regex]::IsMatch ----
    $sw = [System.Diagnostics.Stopwatch]::StartNew()
    1..$iterations | ForEach-Object {
        foreach ($item in $items) {
            $null = [regex]::IsMatch($item, $regexPattern, 'IgnoreCase')
        }
    }
    $sw.Stop()
    $isMatchTime = $sw.ElapsedMilliseconds

    # ---- 测试双指针 ----
    $sw = [System.Diagnostics.Stopwatch]::StartNew()
    1..$iterations | ForEach-Object {
        foreach ($item in $items) {
            $null = Test-DoublePointer -Filter $filter -Text $item
        }
    }
    $sw.Stop()
    $pointerTime = $sw.ElapsedMilliseconds

    $best = [math]::Min($matchTime, [math]::Min($isMatchTime, $pointerTime))
    $bestName = if ($best -eq $pointerTime) { "双指针" } elseif ($best -eq $matchTime) { "-match" } else { "[regex]::IsMatch" }

    Write-Host "  -match          : ${matchTime}ms" -ForegroundColor Green
    Write-Host "  [regex]::IsMatch: ${isMatchTime}ms" -ForegroundColor Cyan
    Write-Host "  双指针手写      : ${pointerTime}ms" -ForegroundColor Magenta
    Write-Host "  => 最快: $bestName" -ForegroundColor DarkGray
    Write-Host ""
}

# ---- 正确性验证 ----
Write-Host "===== 正确性验证 =====" -ForegroundColor Cyan
$testPairs = @(
    @{ filter = 'cp'; text = 'cherry-pick'; expected = $true },
    @{ filter = 'cp'; text = 'fetch-pack';  expected = $false },
    @{ filter = 'ch'; text = 'cherry-pick'; expected = $true },
    @{ filter = 'ch'; text = 'commit';      expected = $false },
    @{ filter = 'c';  text = 'checkout';    expected = $true },
    @{ filter = 'c';  text = 'add';         expected = $false },
    @{ filter = 'gst'; text = 'get-service'; expected = $false },
    @{ filter = 'gst'; text = 'git-status';  expected = $true },
    @{ filter = 'co';  text = 'checkout';    expected = $true },
    @{ filter = 'co';  text = 'commit';      expected = $true },
    @{ filter = 'co';  text = 'cherry-pick'; expected = $false },
    @{ filter = 'co';  text = 'add';         expected = $false }
)

$allPass = $true
foreach ($tp in $testPairs) {
    $filter = $tp.filter
    $text = $tp.text
    $expected = $tp.expected

    $regexPattern = '^' + (($filter.ToCharArray() | ForEach-Object { [regex]::Escape($_) }) -join '.*') + '.*'
    $matchResult   = $text -match $regexPattern
    $isMatchResult = [regex]::IsMatch($text, $regexPattern, 'IgnoreCase')
    $pointerResult = Test-DoublePointer -Filter $filter -Text $text

    $matchOk   = $matchResult   -eq $expected
    $isMatchOk = $isMatchResult -eq $expected
    $pointerOk = $pointerResult -eq $expected

    if (-not ($matchOk -and $isMatchOk -and $pointerOk)) {
        Write-Host "✗ filter='$filter' text='$text' => expected=$expected match=$matchResult isMatch=$isMatchResult pointer=$pointerResult" -ForegroundColor Red
        $allPass = $false
    }
}
if ($allPass) {
    Write-Host "正确性: 全部通过 ✅" -ForegroundColor Green
}
else {
    Write-Host "正确性: 有失败项 ❌" -ForegroundColor Red
}
```
