### PR TITLE
fix(completions): fix just hook

### DIFF
--- a/completions/just/hooks.ps1
+++ b/completions/just/hooks.ps1
@@ -17,7 +17,9 @@ function handleCompletions($completions) {
         $list.Add($PSCompletions.return_completion($completion, $tip, $symbol))
     }
     function add_recipes {
-        just --summary 2>$null | ForEach-Object { add $_.Split(' ') }
+        (just --summary 2>$null) -split '\s+' | ForEach-Object {
+            add $_
+        }
     }
 
     if (-not $cmds.Count) {


### PR DESCRIPTION
- Closes #161

先使用 `-split '\s+'` 拆分 `just --summary` 的输出，再通过管道和 `ForEach-Object` 对每个 recipe 分别调用 `add`

```powershell
(just --summary 2>$null) -split '\s+' | ForEach-Object {
    add $_
}
```

~~保留了重构后的函数式写法~~
