### PR TITLE
feat(completions): update dotnet for .NET SDK 10

### DIFF
--- a/completions/dotnet/hooks.lua
+++ b/completions/dotnet/hooks.lua
@@ -47,6 +47,16 @@ local function add_tools()
     end
 end
 
+local function add_tool_commands()
+    -- local tools: command names live in the last column
+    for _, line in ipairs(psc.run({ "dotnet", "tool", "list", "--local" }) or {}) do
+        local name = line:match("(%S+)$")
+        if name and name ~= "Commands" and not name:match("^%-") then
+            psc.add({ name = name, tip = psc.trim(line) })
+        end
+    end
+end
+
 psc.on({
     { command = "run" },
     { command = "store" },
@@ -57,7 +67,9 @@ psc.on({
     { command = "publish",                 multiple = true },
     { command = "pack",                    multiple = true },
     { command = "msbuild",                 multiple = true },
-    { command = "sln" },
+    { command = "solution" },
+    { command = { "solution", "add" },    multiple = true },
+    { command = { "solution", "remove" }, multiple = true },
     { command = { "reference", "add" },    multiple = true },
     { command = { "reference", "remove" }, multiple = true },
     { option = "--project" }
@@ -68,8 +80,8 @@ psc.on({
     { command = { "package", "remove" }, multiple = true },
     { command = { "package", "list" } },
     { command = { "package", "search" } },
-    { command = { "nuget", "add" } },
-    { command = { "nuget", "remove" } }
+    { command = { "package", "update" } },
+    { command = { "package", "download" } }
 }, add_packages)
 
 psc.on({
@@ -78,6 +90,10 @@ psc.on({
     { command = { "tool", "update" } },
     { command = { "tool", "search" } }
 }, add_tools)
+
+psc.on({
+    { command = { "tool", "run" } }
+}, add_tool_commands)
 
 psc.on({
     { command = { "workload", "install" },   multiple = true },
@@ -95,7 +111,8 @@ end)
 psc.on({
     { command = { "new", "install" } },
     { command = { "new", "uninstall" } },
-    { command = { "new", "list" } }
+    { command = { "new", "list" } },
+    { command = { "new", "create" } }
 }, function()
     for _, line in ipairs(psc.run({ "dotnet", "new", "list" }) or {}) do
         local name = line:match("^(%S+)")

--- a/completions/dotnet/language/en-US.json
+++ b/completions/dotnet/language/en-US.json
@@ -9,41 +9,1215 @@
     {
       "name": "build",
       "tip": [
-        "Builds a .NET application."
+        "Build a .NET project."
+      ],
+      "option": [
+        {
+          "name": "--arch",
+          "alias": [
+            "-a"
+          ],
+          "usage": [
+            "-a, --arch <ARCH>"
+          ],
+          "tip": [
+            "The target architecture."
+          ],
+          "next": [
+            {
+              "name": "arm",
+              "tip": [
+                "ARM32"
+              ]
+            },
+            {
+              "name": "arm64",
+              "tip": [
+                "ARM64"
+              ]
+            },
+            {
+              "name": "x64",
+              "tip": [
+                "64-bit x86"
+              ]
+            },
+            {
+              "name": "x86",
+              "tip": [
+                "32-bit x86"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--artifacts-path",
+          "usage": [
+            "--artifacts-path <ARTIFACTS_DIR>"
+          ],
+          "tip": [
+            "The artifacts path. All output from the project, including build, publish, and pack output, will go in subfolders under the specified path."
+          ],
+          "next": []
+        },
+        {
+          "name": "--configuration",
+          "alias": [
+            "-c"
+          ],
+          "usage": [
+            "-c, --configuration <CONFIGURATION>"
+          ],
+          "tip": [
+            "The configuration to use for building the project. The default for most projects is 'Debug'."
+          ],
+          "next": [
+            {
+              "name": "Debug"
+            },
+            {
+              "name": "Release"
+            }
+          ]
+        },
+        {
+          "name": "--disable-build-servers",
+          "tip": [
+            "Force the command to ignore any persistent build servers."
+          ]
+        },
+        {
+          "name": "--framework",
+          "alias": [
+            "-f"
+          ],
+          "usage": [
+            "-f, --framework <FRAMEWORK>"
+          ],
+          "tip": [
+            "The target framework to build for. The target framework must also be specified in the project file."
+          ],
+          "next": [
+            {
+              "name": "net10.0",
+              "tip": [
+                ".NET 10"
+              ]
+            },
+            {
+              "name": "net8.0",
+              "tip": [
+                ".NET 8"
+              ]
+            },
+            {
+              "name": "net9.0",
+              "tip": [
+                ".NET 9"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--interactive",
+          "tip": [
+            "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+          ]
+        },
+        {
+          "name": "--no-dependencies",
+          "tip": [
+            "Do not build project-to-project references and only build the specified project."
+          ]
+        },
+        {
+          "name": "--no-incremental",
+          "tip": [
+            "Do not use incremental building."
+          ]
+        },
+        {
+          "name": "--no-logo",
+          "alias": [
+            "-nologo"
+          ],
+          "usage": [
+            "-nologo, --no-logo"
+          ],
+          "tip": [
+            "Do not display the startup banner or the copyright message."
+          ]
+        },
+        {
+          "name": "--no-restore",
+          "tip": [
+            "Do not restore the project before building."
+          ]
+        },
+        {
+          "name": "--no-self-contained",
+          "tip": [
+            "Publish your application as a framework dependent application. A compatible .NET runtime must be installed on the target machine to run your application."
+          ]
+        },
+        {
+          "name": "--os",
+          "usage": [
+            "--os <OS>"
+          ],
+          "tip": [
+            "The target operating system."
+          ],
+          "next": [
+            {
+              "name": "linux",
+              "tip": [
+                "Linux"
+              ]
+            },
+            {
+              "name": "osx",
+              "tip": [
+                "macOS"
+              ]
+            },
+            {
+              "name": "win",
+              "tip": [
+                "Windows"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--output",
+          "alias": [
+            "-o"
+          ],
+          "usage": [
+            "-o, --output <OUTPUT_DIR>"
+          ],
+          "tip": [
+            "The output directory to place built artifacts in."
+          ],
+          "next": []
+        },
+        {
+          "name": "--runtime",
+          "alias": [
+            "-r"
+          ],
+          "usage": [
+            "-r, --runtime <RUNTIME_IDENTIFIER>"
+          ],
+          "tip": [
+            "The target runtime to build for."
+          ],
+          "next": [
+            {
+              "name": "linux-arm64",
+              "tip": [
+                "Linux ARM64"
+              ]
+            },
+            {
+              "name": "linux-x64",
+              "tip": [
+                "Linux x64"
+              ]
+            },
+            {
+              "name": "osx-arm64",
+              "tip": [
+                "macOS ARM64"
+              ]
+            },
+            {
+              "name": "osx-x64",
+              "tip": [
+                "macOS x64"
+              ]
+            },
+            {
+              "name": "win-arm64",
+              "tip": [
+                "Windows ARM64"
+              ]
+            },
+            {
+              "name": "win-x64",
+              "tip": [
+                "Windows x64"
+              ]
+            },
+            {
+              "name": "win-x86",
+              "tip": [
+                "Windows x86"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--self-contained",
+          "alias": [
+            "--sc"
+          ],
+          "usage": [
+            "--sc, --self-contained"
+          ],
+          "tip": [
+            "Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.",
+            "The default is 'false.' However, when targeting .NET 7 or lower, the default is 'true' if a runtime identifier is specified."
+          ]
+        },
+        {
+          "name": "--use-current-runtime",
+          "alias": [
+            "--ucr"
+          ],
+          "usage": [
+            "--ucr, --use-current-runtime"
+          ],
+          "tip": [
+            "Use current runtime as the target runtime."
+          ]
+        },
+        {
+          "name": "--verbosity",
+          "alias": [
+            "-verbosity",
+            "-v"
+          ],
+          "usage": [
+            "-v, -verbosity, --verbosity <LEVEL>"
+          ],
+          "tip": [
+            "Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]."
+          ],
+          "next": [
+            {
+              "name": "detailed"
+            },
+            {
+              "name": "diagnostic"
+            },
+            {
+              "name": "minimal"
+            },
+            {
+              "name": "normal"
+            },
+            {
+              "name": "quiet"
+            }
+          ]
+        },
+        {
+          "name": "--version-suffix",
+          "usage": [
+            "--version-suffix <VERSION_SUFFIX>"
+          ],
+          "tip": [
+            "Set the value of the $(VersionSuffix) property to use when building the project."
+          ],
+          "next": []
+        }
       ]
     },
     {
       "name": "build-server",
       "tip": [
-        "Interacts with servers started by a build."
+        "Interact with servers started from a build."
+      ],
+      "next": [
+        {
+          "name": "shutdown",
+          "tip": [
+            "Shuts down build servers that are started from dotnet. By default, all servers are shut down."
+          ],
+          "option": [
+            {
+              "name": "--msbuild",
+              "tip": [
+                "Shut down the MSBuild build server."
+              ]
+            },
+            {
+              "name": "--razor",
+              "tip": [
+                "Shut down the Razor build server."
+              ]
+            },
+            {
+              "name": "--vbcscompiler",
+              "tip": [
+                "Shut down the VB/C# compiler build server."
+              ]
+            }
+          ]
+        }
       ]
     },
     {
       "name": "clean",
       "tip": [
-        "Clean build outputs."
-      ]
-    },
-    {
-      "name": "exec",
-      "tip": [
-        "Runs a .NET application."
+        "Clean build outputs of a .NET project."
       ],
       "option": [
         {
-          "name": "--depsfile",
+          "name": "--artifacts-path",
+          "usage": [
+            "--artifacts-path <ARTIFACTS_DIR>"
+          ],
           "tip": [
-            "Path to a deps.json file.",
-            "A deps.json file contains information about dependencies necessary to run the application.",
-            "This file is generated by the .NET SDK."
+            "The artifacts path. All output from the project, including build, publish, and pack output, will go in subfolders under the specified path."
+          ],
+          "next": []
+        },
+        {
+          "name": "--configuration",
+          "alias": [
+            "-c"
+          ],
+          "usage": [
+            "-c, --configuration <CONFIGURATION>"
+          ],
+          "tip": [
+            "The configuration to clean for. The default for most projects is 'Debug'."
+          ],
+          "next": [
+            {
+              "name": "Debug"
+            },
+            {
+              "name": "Release"
+            }
           ]
         },
         {
-          "name": "--runtimeconfig",
+          "name": "--disable-build-servers",
           "tip": [
-            "Path to a runtimeconfig.json file.",
-            "A runtimeconfig.json file contains runtime settings.",
-            "It is typically named <applicationname>.runtimeconfig.json."
+            "Force the command to ignore any persistent build servers."
+          ]
+        },
+        {
+          "name": "--framework",
+          "alias": [
+            "-f"
+          ],
+          "usage": [
+            "-f, --framework <FRAMEWORK>"
+          ],
+          "tip": [
+            "The target framework to clean for. The target framework must also be specified in the project file."
+          ],
+          "next": [
+            {
+              "name": "net10.0",
+              "tip": [
+                ".NET 10"
+              ]
+            },
+            {
+              "name": "net8.0",
+              "tip": [
+                ".NET 8"
+              ]
+            },
+            {
+              "name": "net9.0",
+              "tip": [
+                ".NET 9"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--interactive",
+          "tip": [
+            "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+          ]
+        },
+        {
+          "name": "--no-logo",
+          "alias": [
+            "-nologo"
+          ],
+          "usage": [
+            "-nologo, --no-logo"
+          ],
+          "tip": [
+            "Do not display the startup banner or the copyright message."
+          ]
+        },
+        {
+          "name": "--output",
+          "alias": [
+            "-o"
+          ],
+          "usage": [
+            "-o, --output <OUTPUT_DIR>"
+          ],
+          "tip": [
+            "The directory containing the build artifacts to clean."
+          ],
+          "next": []
+        },
+        {
+          "name": "--runtime",
+          "alias": [
+            "-r"
+          ],
+          "usage": [
+            "-r, --runtime <RUNTIME_IDENTIFIER>"
+          ],
+          "tip": [
+            "The target runtime to clean for."
+          ],
+          "next": [
+            {
+              "name": "linux-x64",
+              "tip": [
+                "Linux x64"
+              ]
+            },
+            {
+              "name": "osx-arm64",
+              "tip": [
+                "macOS ARM64"
+              ]
+            },
+            {
+              "name": "win-x64",
+              "tip": [
+                "Windows x64"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--verbosity",
+          "alias": [
+            "-v"
+          ],
+          "usage": [
+            "-v, --verbosity <LEVEL>"
+          ],
+          "tip": [
+            "Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]. [default: normal]"
+          ],
+          "next": [
+            {
+              "name": "detailed"
+            },
+            {
+              "name": "diagnostic"
+            },
+            {
+              "name": "minimal"
+            },
+            {
+              "name": "normal"
+            },
+            {
+              "name": "quiet"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "dev-certs",
+      "tip": [
+        "Create and manage development certificates."
+      ],
+      "next": [
+        {
+          "name": "https",
+          "usage": [
+            "https [options]"
+          ],
+          "tip": [
+            "Create, trust, and export HTTPS development certificates."
+          ],
+          "option": [
+            {
+              "name": "--check",
+              "alias": [
+                "-c"
+              ],
+              "usage": [
+                "-c, --check"
+              ],
+              "tip": [
+                "Check for the existence of the certificate but do not perform any action."
+              ]
+            },
+            {
+              "name": "--check-trust-machine-readable",
+              "tip": [
+                "Same as running --check --trust, but output the results in json."
+              ]
+            },
+            {
+              "name": "--clean",
+              "tip": [
+                "Cleans all HTTPS development certificates from the machine."
+              ]
+            },
+            {
+              "name": "--export-path",
+              "alias": [
+                "-ep"
+              ],
+              "usage": [
+                "-ep, --export-path <PATH>"
+              ],
+              "tip": [
+                "Full path to the exported certificate."
+              ],
+              "next": []
+            },
+            {
+              "name": "--format",
+              "usage": [
+                "--format <PFX|PEM>"
+              ],
+              "tip": [
+                "Export the certificate in the given format. Valid values are Pfx and Pem. Pfx is the default."
+              ],
+              "next": [
+                {
+                  "name": "Pem"
+                },
+                {
+                  "name": "Pfx"
+                }
+              ]
+            },
+            {
+              "name": "--import",
+              "alias": [
+                "-i"
+              ],
+              "usage": [
+                "-i, --import"
+              ],
+              "tip": [
+                "Imports the provided HTTPS development certificate into the machine. All other HTTPS developer certificates will be cleared out."
+              ]
+            },
+            {
+              "name": "--no-password",
+              "alias": [
+                "-np"
+              ],
+              "usage": [
+                "-np, --no-password"
+              ],
+              "tip": [
+                "Explicitly request that you don't use a password for the key when exporting a certificate to a PEM format."
+              ]
+            },
+            {
+              "name": "--password",
+              "alias": [
+                "-p"
+              ],
+              "usage": [
+                "-p, --password <PASSWORD>"
+              ],
+              "tip": [
+                "Password to use when exporting the certificate with the private key into a pfx file or to encrypt the Pem exported key."
+              ],
+              "next": []
+            },
+            {
+              "name": "--quiet",
+              "alias": [
+                "-q"
+              ],
+              "usage": [
+                "-q, --quiet"
+              ],
+              "tip": [
+                "Display warnings and errors only."
+              ]
+            },
+            {
+              "name": "--trust",
+              "alias": [
+                "-t"
+              ],
+              "usage": [
+                "-t, --trust"
+              ],
+              "tip": [
+                "When not combined with the --check option, trusts the certificate on the current platform, creating one if necessary.",
+                "When combined with the --check option, validates that there is a certificate and it is trusted."
+              ]
+            },
+            {
+              "name": "--verbose",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbose"
+              ],
+              "tip": [
+                "Display more debug information."
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "format",
+      "tip": [
+        "Apply style preferences to a project or solution."
+      ],
+      "option": [
+        {
+          "name": "--binarylog",
+          "usage": [
+            "--binarylog <BINARY_LOG_PATH>"
+          ],
+          "tip": [
+            "Logs all project or solution loading information to a binary log file."
+          ],
+          "next": []
+        },
+        {
+          "name": "--diagnostics",
+          "usage": [
+            "--diagnostics <DIAGNOSTICS>"
+          ],
+          "tip": [
+            "A space-separated list of diagnostic IDs to use as a filter when fixing code style or third-party issues."
+          ],
+          "next": []
+        },
+        {
+          "name": "--exclude",
+          "usage": [
+            "--exclude <EXCLUDE>"
+          ],
+          "tip": [
+            "A list of relative paths to files or folders to exclude from formatting."
+          ],
+          "repeat": 99,
+          "next": []
+        },
+        {
+          "name": "--exclude-diagnostics",
+          "usage": [
+            "--exclude-diagnostics <DIAGNOSTICS>"
+          ],
+          "tip": [
+            "A space-separated list of diagnostic IDs to ignore when fixing code style or third-party issues."
+          ],
+          "next": []
+        },
+        {
+          "name": "--include",
+          "usage": [
+            "--include <INCLUDE>"
+          ],
+          "tip": [
+            "A list of relative paths to files or folders to format. If empty, all files are formatted."
+          ],
+          "repeat": 99,
+          "next": []
+        },
+        {
+          "name": "--include-generated",
+          "tip": [
+            "Formats files generated by the SDK."
+          ]
+        },
+        {
+          "name": "--no-restore",
+          "tip": [
+            "Doesn't execute an implicit restore before formatting."
+          ]
+        },
+        {
+          "name": "--report",
+          "usage": [
+            "--report <REPORT_PATH>"
+          ],
+          "tip": [
+            "Accepts a file path that will generate a JSON report in the given directory (if provided)."
+          ],
+          "next": []
+        },
+        {
+          "name": "--severity",
+          "usage": [
+            "--severity <SEVERITY>"
+          ],
+          "tip": [
+            "The severity of diagnostics to fix. Allowed values are info, warn, and error."
+          ],
+          "next": [
+            {
+              "name": "error"
+            },
+            {
+              "name": "hidden"
+            },
+            {
+              "name": "info"
+            },
+            {
+              "name": "warn"
+            }
+          ]
+        },
+        {
+          "name": "--verbosity",
+          "alias": [
+            "-v"
+          ],
+          "usage": [
+            "-v, --verbosity <LEVEL>"
+          ],
+          "tip": [
+            "Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]."
+          ],
+          "next": [
+            {
+              "name": "detailed"
+            },
+            {
+              "name": "diagnostic"
+            },
+            {
+              "name": "minimal"
+            },
+            {
+              "name": "normal"
+            },
+            {
+              "name": "quiet"
+            }
+          ]
+        },
+        {
+          "name": "--verify-no-changes",
+          "tip": [
+            "Verifies that no formatting changes will be made. Terminates with a non-zero exit code if any files would have been formatted."
+          ]
+        },
+        {
+          "name": "--version",
+          "tip": [
+            "Display version information."
+          ]
+        }
+      ],
+      "next": [
+        {
+          "name": "analyzers",
+          "usage": [
+            "analyzers [<PROJECT | SOLUTION>]"
+          ],
+          "tip": [
+            "Runs third-party analyzers and applies fixes."
+          ]
+        },
+        {
+          "name": "style",
+          "usage": [
+            "style [<PROJECT | SOLUTION>]"
+          ],
+          "tip": [
+            "Runs code style analyzers and applies fixes."
+          ]
+        },
+        {
+          "name": "whitespace",
+          "usage": [
+            "whitespace [<PROJECT | SOLUTION>]"
+          ],
+          "tip": [
+            "Runs whitespace formatting."
+          ]
+        }
+      ]
+    },
+    {
+      "name": "fsi",
+      "tip": [
+        "Start F# Interactive / execute F# scripts."
+      ],
+      "option": [
+        {
+          "name": "--checked",
+          "usage": [
+            "--checked[+|-]"
+          ],
+          "tip": [
+            "Generate overflow checks (off by default)."
+          ],
+          "next": [
+            {
+              "name": "-"
+            },
+            {
+              "name": "+"
+            }
+          ]
+        },
+        {
+          "name": "--codepage",
+          "usage": [
+            "--codepage:<n>"
+          ],
+          "tip": [
+            "Specify the code page used to read source files."
+          ],
+          "next": []
+        },
+        {
+          "name": "--compilertool",
+          "alias": [
+            "-t"
+          ],
+          "usage": [
+            "-t, --compilertool:<file>"
+          ],
+          "tip": [
+            "Reference an assembly or directory containing a design-time tool."
+          ],
+          "next": []
+        },
+        {
+          "name": "--debug",
+          "alias": [
+            "-g"
+          ],
+          "usage": [
+            "-g, --debug[+|-]"
+          ],
+          "tip": [
+            "Emit debug information (on by default)."
+          ],
+          "next": [
+            {
+              "name": "-"
+            },
+            {
+              "name": "+"
+            },
+            {
+              "name": "embedded"
+            },
+            {
+              "name": "full"
+            },
+            {
+              "name": "pdbonly"
+            },
+            {
+              "name": "portable"
+            }
+          ]
+        },
+        {
+          "name": "--define",
+          "alias": [
+            "-d"
+          ],
+          "usage": [
+            "-d, --define:<string>"
+          ],
+          "tip": [
+            "Define a conditional compilation symbol."
+          ],
+          "next": []
+        },
+        {
+          "name": "--deterministic",
+          "usage": [
+            "--deterministic[+|-]"
+          ],
+          "tip": [
+            "Produce a deterministic assembly (off by default)."
+          ],
+          "next": [
+            {
+              "name": "-"
+            },
+            {
+              "name": "+"
+            }
+          ]
+        },
+        {
+          "name": "--exec",
+          "tip": [
+            "Exit fsi after loading the files or running the given .fsx script on the command line."
+          ]
+        },
+        {
+          "name": "--langversion",
+          "usage": [
+            "--langversion:<VERSION>"
+          ],
+          "tip": [
+            "Specify a language version, such as \"latest\" or \"preview\"."
+          ],
+          "next": [
+            {
+              "name": "latest"
+            },
+            {
+              "name": "preview"
+            }
+          ]
+        },
+        {
+          "name": "--lib",
+          "alias": [
+            "-I"
+          ],
+          "usage": [
+            "-I, --lib:<dir;...>"
+          ],
+          "tip": [
+            "Specify a directory for the include path used to resolve source files and assemblies."
+          ],
+          "next": []
+        },
+        {
+          "name": "--load",
+          "usage": [
+            "--load:<file>"
+          ],
+          "tip": [
+            "#load the given file on startup."
+          ],
+          "next": []
+        },
+        {
+          "name": "--multiemit",
+          "usage": [
+            "--multiemit[+|-]"
+          ],
+          "tip": [
+            "Emit multiple assemblies (on by default)."
+          ],
+          "next": [
+            {
+              "name": "-"
+            },
+            {
+              "name": "+"
+            }
+          ]
+        },
+        {
+          "name": "--nologo",
+          "tip": [
+            "Suppress the display of the compiler copyright banner."
+          ]
+        },
+        {
+          "name": "--nowarn",
+          "usage": [
+            "--nowarn:<warn;...>"
+          ],
+          "tip": [
+            "Disable specific warning messages."
+          ],
+          "next": []
+        },
+        {
+          "name": "--optimize",
+          "alias": [
+            "-O"
+          ],
+          "usage": [
+            "-O, --optimize[+|-]"
+          ],
+          "tip": [
+            "Enable optimizations (on by default)."
+          ],
+          "next": [
+            {
+              "name": "-"
+            },
+            {
+              "name": "+"
+            }
+          ]
+        },
+        {
+          "name": "--quiet",
+          "tip": [
+            "Suppress fsi writing to stdout."
+          ]
+        },
+        {
+          "name": "--readline",
+          "usage": [
+            "--readline[+|-]"
+          ],
+          "tip": [
+            "Support TAB completion in console (on by default)."
+          ],
+          "next": [
+            {
+              "name": "-"
+            },
+            {
+              "name": "+"
+            }
+          ]
+        },
+        {
+          "name": "--reference",
+          "alias": [
+            "-r"
+          ],
+          "usage": [
+            "-r, --reference:<file>"
+          ],
+          "tip": [
+            "Reference an assembly."
+          ],
+          "next": []
+        },
+        {
+          "name": "--tailcalls",
+          "usage": [
+            "--tailcalls[+|-]"
+          ],
+          "tip": [
+            "Enable or disable tailcalls (on by default)."
+          ],
+          "next": [
+            {
+              "name": "-"
+            },
+            {
+              "name": "+"
+            }
+          ]
+        },
+        {
+          "name": "--targetprofile",
+          "usage": [
+            "--targetprofile:<string>"
+          ],
+          "tip": [
+            "Specify the target framework profile of this assembly. Valid values are mscorlib, netcore, or netstandard. Default: mscorlib."
+          ],
+          "next": [
+            {
+              "name": "mscorlib"
+            },
+            {
+              "name": "netcore"
+            },
+            {
+              "name": "netstandard"
+            }
+          ]
+        },
+        {
+          "name": "--typecheck-only",
+          "tip": [
+            "Perform type checking only, do not execute code."
+          ]
+        },
+        {
+          "name": "--use",
+          "usage": [
+            "--use:<file>"
+          ],
+          "tip": [
+            "Use the given file as initial input on startup."
+          ],
+          "next": []
+        },
+        {
+          "name": "--usesdkrefs",
+          "usage": [
+            "--usesdkrefs[+|-]"
+          ],
+          "tip": [
+            "Use reference assemblies for .NET Framework references when available (enabled by default)."
+          ],
+          "next": [
+            {
+              "name": "-"
+            },
+            {
+              "name": "+"
+            }
+          ]
+        },
+        {
+          "name": "--utf8output",
+          "tip": [
+            "Output messages in UTF-8 encoding."
+          ]
+        },
+        {
+          "name": "--version",
+          "tip": [
+            "Display the compiler version banner and exit."
+          ]
+        },
+        {
+          "name": "--warn",
+          "usage": [
+            "--warn:<level>"
+          ],
+          "tip": [
+            "Set a warning level (0-5)."
+          ],
+          "next": [
+            {
+              "name": "0"
+            },
+            {
+              "name": "1"
+            },
+            {
+              "name": "2"
+            },
+            {
+              "name": "3"
+            },
+            {
+              "name": "4"
+            },
+            {
+              "name": "5"
+            }
+          ]
+        },
+        {
+          "name": "--warnaserror",
+          "usage": [
+            "--warnaserror[+|-]"
+          ],
+          "tip": [
+            "Report all warnings as errors (off by default)."
+          ],
+          "next": [
+            {
+              "name": "-"
+            },
+            {
+              "name": "+"
+            }
           ]
         }
       ]
@@ -51,25 +1225,486 @@
     {
       "name": "help",
       "tip": [
-        "Shows more detailed documentation online for the command."
+        "Opens the reference page in a browser for the specified command."
       ]
     },
     {
       "name": "msbuild",
       "tip": [
-        "Provides access to the MSBuild command line."
+        "Run Microsoft Build Engine (MSBuild) commands."
+      ],
+      "option": [
+        {
+          "name": "-binaryLogger",
+          "alias": [
+            "-bl"
+          ],
+          "usage": [
+            "-bl, -binaryLogger [LOGFILE]"
+          ],
+          "tip": [
+            "Serialize all build events to a compressed binary file."
+          ],
+          "next": []
+        },
+        {
+          "name": "-check",
+          "tip": [
+            "Error if the project configuration is invalid."
+          ]
+        },
+        {
+          "name": "-consoleLoggerParameters",
+          "alias": [
+            "-clp"
+          ],
+          "usage": [
+            "-clp, -consoleLoggerParameters <PARAMETERS>"
+          ],
+          "tip": [
+            "Parameters to the console logger. The available parameters are PerformanceSummary, Summary, NoSummary, ErrorsOnly, WarningsOnly, and more."
+          ],
+          "next": []
+        },
+        {
+          "name": "-detailedSummary",
+          "usage": [
+            "-detailedSummary [TRUE|FALSE]"
+          ],
+          "tip": [
+            "Show detailed build summary information at the end of the build."
+          ],
+          "next": [
+            {
+              "name": "False"
+            },
+            {
+              "name": "True"
+            }
+          ]
+        },
+        {
+          "name": "-distributedFileLogger",
+          "alias": [
+            "-dfl"
+          ],
+          "usage": [
+            "-dfl, -distributedFileLogger"
+          ],
+          "tip": [
+            "Log the build output for each MSBuild node to its own file."
+          ]
+        },
+        {
+          "name": "-distributedLogger",
+          "alias": [
+            "-dl"
+          ],
+          "usage": [
+            "-dl, -distributedLogger <CENTRAL_LOGGER>*<FORWARDING_LOGGER>"
+          ],
+          "tip": [
+            "Use this logger to log events from MSBuild, attaching a different logger instance to each node."
+          ],
+          "next": []
+        },
+        {
+          "name": "-fileLogger",
+          "alias": [
+            "-fl"
+          ],
+          "usage": [
+            "-fl, -fileLogger"
+          ],
+          "tip": [
+            "Logs the build output to a file. By default the file is named msbuild.log in the current directory."
+          ]
+        },
+        {
+          "name": "-fileLoggerParameters",
+          "alias": [
+            "-flp"
+          ],
+          "usage": [
+            "-flp, -fileLoggerParameters <PARAMETERS>"
+          ],
+          "tip": [
+            "Parameters to the file logger."
+          ],
+          "next": []
+        },
+        {
+          "name": "-getItem",
+          "usage": [
+            "-getItem <ITEMNAME,...>"
+          ],
+          "tip": [
+            "Gets the items of the specified item type or types."
+          ],
+          "next": []
+        },
+        {
+          "name": "-getProperty",
+          "usage": [
+            "-getProperty <PROPERTYNAME,...>"
+          ],
+          "tip": [
+            "Gets the value of the specified property or properties."
+          ],
+          "next": []
+        },
+        {
+          "name": "-getResultOutputFile",
+          "usage": [
+            "-getResultOutputFile <FILE>"
+          ],
+          "tip": [
+            "Gets the default path that would be used for the results output file."
+          ],
+          "next": []
+        },
+        {
+          "name": "-getTargetResult",
+          "usage": [
+            "-getTargetResult <TARGETNAME,...>"
+          ],
+          "tip": [
+            "Gets the result of the specified target or targets."
+          ],
+          "next": []
+        },
+        {
+          "name": "-graphBuild",
+          "usage": [
+            "-graphBuild [TRUE|FALSE]"
+          ],
+          "tip": [
+            "Instructs MSBuild to construct and build a project graph."
+          ],
+          "next": [
+            {
+              "name": "False"
+            },
+            {
+              "name": "True"
+            }
+          ]
+        },
+        {
+          "name": "-ignoreProjectExtensions",
+          "usage": [
+            "-ignoreProjectExtensions <EXTENSIONS>"
+          ],
+          "tip": [
+            "Ignore the specified extensions when determining which project file to use."
+          ],
+          "next": []
+        },
+        {
+          "name": "-interactive",
+          "usage": [
+            "-interactive [TRUE|FALSE]"
+          ],
+          "tip": [
+            "Indicates that the build will allow interactive user input."
+          ],
+          "next": [
+            {
+              "name": "False"
+            },
+            {
+              "name": "True"
+            }
+          ]
+        },
+        {
+          "name": "-isolateProjects",
+          "usage": [
+            "-isolateProjects [TRUE|MESSAGEUPONISOLATIONVIOLATION|FALSE]"
+          ],
+          "tip": [
+            "Instructs MSBuild to isolate projects for build isolation."
+          ],
+          "next": [
+            {
+              "name": "False"
+            },
+            {
+              "name": "MessageUponIsolationViolation"
+            },
+            {
+              "name": "True"
+            }
+          ]
+        },
+        {
+          "name": "-logger",
+          "alias": [
+            "-l"
+          ],
+          "usage": [
+            "-l, -logger <LOGGER>"
+          ],
+          "tip": [
+            "Use this logger to log events from MSBuild. To specify multiple loggers, specify each logger separately."
+          ],
+          "repeat": 99,
+          "next": []
+        },
+        {
+          "name": "-lowPriority",
+          "usage": [
+            "-lowPriority [TRUE|FALSE]"
+          ],
+          "tip": [
+            "Runs the build at low process priority."
+          ],
+          "next": [
+            {
+              "name": "False"
+            },
+            {
+              "name": "True"
+            }
+          ]
+        },
+        {
+          "name": "-maxCpuCount",
+          "alias": [
+            "-m"
+          ],
+          "usage": [
+            "-m, -maxCpuCount [N]"
+          ],
+          "tip": [
+            "Specifies the maximum number of concurrent processes to use when building."
+          ],
+          "next": []
+        },
+        {
+          "name": "-noAutoResponse",
+          "tip": [
+            "Do not auto-include any MSBuild.rsp files."
+          ]
+        },
+        {
+          "name": "-noConsoleLogger",
+          "tip": [
+            "Disable the default console logger and do not log events to the console."
+          ]
+        },
+        {
+          "name": "-nodeReuse",
+          "alias": [
+            "-nr"
+          ],
+          "usage": [
+            "-nr, -nodeReuse <TRUE|FALSE>"
+          ],
+          "tip": [
+            "Enable or disable the reuse of MSBuild nodes."
+          ],
+          "next": [
+            {
+              "name": "False"
+            },
+            {
+              "name": "True"
+            }
+          ]
+        },
+        {
+          "name": "-noLogo",
+          "usage": [
+            "-noLogo [TRUE|FALSE]"
+          ],
+          "tip": [
+            "Do not display the startup banner and copyright message."
+          ],
+          "next": [
+            {
+              "name": "False"
+            },
+            {
+              "name": "True"
+            }
+          ]
+        },
+        {
+          "name": "-preprocess",
+          "alias": [
+            "-pp"
+          ],
+          "usage": [
+            "-pp, -preprocess [FILE]"
+          ],
+          "tip": [
+            "Creates a single, aggregated project file that includes all the files that would be used during the build."
+          ],
+          "next": []
+        },
+        {
+          "name": "-property",
+          "alias": [
+            "-p"
+          ],
+          "usage": [
+            "-p, -property <NAME>=<VALUE>"
+          ],
+          "tip": [
+            "Set or override these project-level properties. Use a semicolon or a comma to separate multiple properties."
+          ],
+          "repeat": 99,
+          "next": []
+        },
+        {
+          "name": "-question",
+          "tip": [
+            "Returns a summary of potential issues and exits."
+          ]
+        },
+        {
+          "name": "-restore",
+          "alias": [
+            "-r"
+          ],
+          "usage": [
+            "-r, -restore [TRUE|FALSE]"
+          ],
+          "tip": [
+            "Run a target to restore the project before building."
+          ],
+          "next": [
+            {
+              "name": "False"
+            },
+            {
+              "name": "True"
+            }
+          ]
+        },
+        {
+          "name": "-target",
+          "alias": [
+            "-t"
+          ],
+          "usage": [
+            "-t, -target <TARGETS>"
+          ],
+          "tip": [
+            "Build these targets in this project. Use a semicolon or a comma to separate multiple targets."
+          ],
+          "next": []
+        },
+        {
+          "name": "-targets",
+          "alias": [
+            "-ts"
+          ],
+          "usage": [
+            "-ts, -targets [FILE]"
+          ],
+          "tip": [
+            "Displays the list of targets in the project and exits."
+          ],
+          "next": []
+        },
+        {
+          "name": "-toolsVersion",
+          "alias": [
+            "-tv"
+          ],
+          "usage": [
+            "-tv, -toolsVersion <VERSION>"
+          ],
+          "tip": [
+            "Specifies the version of the toolset to use to build the project."
+          ],
+          "next": []
+        },
+        {
+          "name": "-verbosity",
+          "alias": [
+            "-v"
+          ],
+          "usage": [
+            "-v, -verbosity <LEVEL>"
+          ],
+          "tip": [
+            "Display this amount of information in the event log. The available verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]."
+          ],
+          "next": [
+            {
+              "name": "detailed"
+            },
+            {
+              "name": "diagnostic"
+            },
+            {
+              "name": "minimal"
+            },
+            {
+              "name": "normal"
+            },
+            {
+              "name": "quiet"
+            }
+          ]
+        },
+        {
+          "name": "-version",
+          "alias": [
+            "-ver"
+          ],
+          "usage": [
+            "-ver, -version"
+          ],
+          "tip": [
+            "Display version information only."
+          ]
+        },
+        {
+          "name": "-warnAsError",
+          "usage": [
+            "-warnAsError [CODE[;CODE2]]"
+          ],
+          "tip": [
+            "Treat warnings as errors. Optionally provide a specific warning code or codes to treat as errors."
+          ],
+          "next": []
+        },
+        {
+          "name": "-warnAsMessage",
+          "usage": [
+            "-warnAsMessage [CODE[;CODE2]]"
+          ],
+          "tip": [
+            "Treat warnings as messages. Optionally provide a specific warning code or codes to treat as messages."
+          ],
+          "next": []
+        },
+        {
+          "name": "-warnNotAsError",
+          "usage": [
+            "-warnNotAsError [CODE[;CODE2]]"
+          ],
+          "tip": [
+            "Treat specific warnings as non-errors, overriding -warnAsError."
+          ],
+          "next": []
+        }
       ]
     },
     {
       "name": "new",
       "tip": [
-        "Initializes a C# or F# project for a given template."
+        "Create a new .NET project or file."
       ],
       "option": [
         {
           "name": "--dry-run",
           "tip": [
-            "Displays a summary of what would happen if the given command were run if it would result in a template creation."
+            "Displays a summary of what would happen if the given command line were run if it would result in a template creation."
           ]
         },
         {
@@ -84,11 +1719,37 @@
             "-f"
           ],
           "usage": [
-            "-f, --framework"
+            "-f, --framework <FRAMEWORK>"
           ],
           "tip": [
             "Specifies the target framework.",
-            "Examples: \"net6.0\", \"net7.0-macos\"."
+            "Examples: \"net10.0\", \"net9.0-macos\"."
+          ],
+          "next": [
+            {
+              "name": "net10.0",
+              "tip": [
+                ".NET 10"
+              ]
+            },
+            {
+              "name": "net8.0",
+              "tip": [
+                ".NET 8"
+              ]
+            },
+            {
+              "name": "net9.0",
+              "tip": [
+                ".NET 9"
+              ]
+            },
+            {
+              "name": "netstandard2.0",
+              "tip": [
+                ".NET Standard 2.0"
+              ]
+            }
           ]
         },
         {
@@ -97,13 +1758,33 @@
             "-lang"
           ],
           "usage": [
-            "-lang, --language"
+            "-lang, --language <LANGUAGE>"
           ],
           "tip": [
             "The language of the template to create.",
             "The language accepted varies by the template.",
             "Not valid for some templates.",
-            "Supported language: [C#|F#|VB]"
+            "Supported languages: [C#|F#|VB]"
+          ],
+          "next": [
+            {
+              "name": "C#",
+              "tip": [
+                "C#"
+              ]
+            },
+            {
+              "name": "F#",
+              "tip": [
+                "F#"
+              ]
+            },
+            {
+              "name": "VB",
+              "tip": [
+                "Visual Basic"
+              ]
+            }
           ]
         },
         {
@@ -112,11 +1793,17 @@
             "-n"
           ],
           "usage": [
-            "-n, --name"
+            "-n, --name <NAME>"
           ],
           "tip": [
-            "The name for the created output.",
-            "If no name is specified, the name of the current directory is used."
+            "The name for the output being created. If no name is specified, the name of the output directory is used."
+          ],
+          "next": []
+        },
+        {
+          "name": "--no-update-check",
+          "tip": [
+            "Disables checking for the template package updates when instantiating a template."
           ]
         },
         {
@@ -125,62 +1812,670 @@
             "-o"
           ],
           "usage": [
-            "-o, --output"
+            "-o, --output <OUTPUT>"
           ],
           "tip": [
-            "Location to place the generated output.",
-            "The default is the current directory."
-          ]
+            "Location to place the generated output."
+          ],
+          "next": []
         },
         {
           "name": "--project",
+          "usage": [
+            "--project <PROJECT>"
+          ],
           "tip": [
-            "The project that the template is added to.",
-            "If not specified, the project in the current or parent directories will be used."
-          ]
+            "The project that should be used for context evaluation."
+          ],
+          "next": []
         },
         {
-          "name": "-no-update-check",
+          "name": "--verbosity",
+          "alias": [
+            "-v"
+          ],
+          "usage": [
+            "-v, --verbosity <LEVEL>"
+          ],
           "tip": [
-            "Disables checking for template package updates when instantiating a template."
+            "Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], and diag[nostic]. [default: normal]"
+          ],
+          "next": [
+            {
+              "name": "diagnostic"
+            },
+            {
+              "name": "minimal"
+            },
+            {
+              "name": "normal"
+            },
+            {
+              "name": "quiet"
+            }
           ]
         }
       ],
       "next": [
         {
-          "name": "details",
+          "name": "create",
+          "usage": [
+            "create <TEMPLATE_SHORT_NAME>"
+          ],
           "tip": [
-            "Displays template package metadata."
+            "Instantiates a template with given short name. An alias of 'dotnet new <template name>'."
+          ],
+          "option": [
+            {
+              "name": "--dry-run",
+              "tip": [
+                "Displays a summary of what would happen if the given command line were run if it would result in a template creation."
+              ]
+            },
+            {
+              "name": "--force",
+              "tip": [
+                "Forces content to be generated even if it would change existing files."
+              ]
+            },
+            {
+              "name": "--name",
+              "alias": [
+                "-n"
+              ],
+              "usage": [
+                "-n, --name <NAME>"
+              ],
+              "tip": [
+                "The name for the output being created. If no name is specified, the name of the output directory is used."
+              ],
+              "next": []
+            },
+            {
+              "name": "--no-update-check",
+              "tip": [
+                "Disables checking for the template package updates when instantiating a template."
+              ]
+            },
+            {
+              "name": "--output",
+              "alias": [
+                "-o"
+              ],
+              "usage": [
+                "-o, --output <OUTPUT>"
+              ],
+              "tip": [
+                "Location to place the generated output."
+              ],
+              "next": []
+            },
+            {
+              "name": "--project",
+              "usage": [
+                "--project <PROJECT>"
+              ],
+              "tip": [
+                "The project that should be used for context evaluation."
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], and diag[nostic]. [default: normal]"
+              ],
+              "next": [
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "details",
+          "usage": [
+            "details <PACKAGE_IDENTIFIER>"
+          ],
+          "tip": [
+            "Provides the details for specified template package.",
+            "The command checks if the package is installed locally, if it was not found, it searches the configured NuGet feeds."
+          ],
+          "option": [
+            {
+              "name": "--interactive",
+              "tip": [
+                "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+              ]
+            },
+            {
+              "name": "--nuget-source",
+              "alias": [
+                "--add-source"
+              ],
+              "usage": [
+                "--add-source, --nuget-source <NUGET_SOURCE>"
+              ],
+              "tip": [
+                "Specifies a NuGet source to use."
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], and diag[nostic]. [default: normal]"
+              ],
+              "next": [
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
           ]
         },
         {
           "name": "install",
+          "usage": [
+            "install <PACKAGE>"
+          ],
           "tip": [
-            "installs a template package."
+            "Installs a template package."
+          ],
+          "option": [
+            {
+              "name": "--force",
+              "tip": [
+                "Allows installing template packages from the specified sources even if they would override a template package from another source."
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+              ]
+            },
+            {
+              "name": "--nuget-source",
+              "alias": [
+                "--add-source"
+              ],
+              "usage": [
+                "--add-source, --nuget-source <NUGET_SOURCE>"
+              ],
+              "tip": [
+                "Specifies a NuGet source to use."
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], and diag[nostic]. [default: normal]"
+              ],
+              "next": [
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
           ]
         },
         {
           "name": "list",
+          "usage": [
+            "list [<TEMPLATE_NAME>]"
+          ],
           "tip": [
-            "Lists available templates to be run using dotnet new."
+            "Lists templates containing the specified template name. If no name is specified, lists all templates."
+          ],
+          "option": [
+            {
+              "name": "--author",
+              "usage": [
+                "--author <AUTHOR>"
+              ],
+              "tip": [
+                "Filters the templates based on the template author."
+              ],
+              "next": []
+            },
+            {
+              "name": "--columns",
+              "usage": [
+                "--columns <AUTHOR|LANGUAGE|TAGS|TYPE>"
+              ],
+              "tip": [
+                "Specifies the columns to display in the output."
+              ],
+              "next": [
+                {
+                  "name": "author"
+                },
+                {
+                  "name": "language"
+                },
+                {
+                  "name": "tags"
+                },
+                {
+                  "name": "type"
+                }
+              ]
+            },
+            {
+              "name": "--columns-all",
+              "tip": [
+                "Displays all columns in the output."
+              ]
+            },
+            {
+              "name": "--ignore-constraints",
+              "tip": [
+                "Disables checking if the template meets the constraints to be run."
+              ]
+            },
+            {
+              "name": "--language",
+              "alias": [
+                "-lang"
+              ],
+              "usage": [
+                "-lang, --language <LANGUAGE>"
+              ],
+              "tip": [
+                "Filters templates based on language."
+              ],
+              "next": [
+                {
+                  "name": "C#",
+                  "tip": [
+                    "C#"
+                  ]
+                },
+                {
+                  "name": "F#",
+                  "tip": [
+                    "F#"
+                  ]
+                },
+                {
+                  "name": "VB",
+                  "tip": [
+                    "Visual Basic"
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "--output",
+              "alias": [
+                "-o"
+              ],
+              "usage": [
+                "-o, --output <OUTPUT>"
+              ],
+              "tip": [
+                "Location to place the generated output."
+              ],
+              "next": []
+            },
+            {
+              "name": "--project",
+              "usage": [
+                "--project <PROJECT>"
+              ],
+              "tip": [
+                "The project that should be used for context evaluation."
+              ],
+              "next": []
+            },
+            {
+              "name": "--tag",
+              "usage": [
+                "--tag <TAG>"
+              ],
+              "tip": [
+                "Filters the templates based on the tag."
+              ],
+              "next": []
+            },
+            {
+              "name": "--type",
+              "usage": [
+                "--type <TYPE>"
+              ],
+              "tip": [
+                "Filters templates based on available types. Predefined values are \"project\" and \"item\"."
+              ],
+              "next": [
+                {
+                  "name": "item"
+                },
+                {
+                  "name": "project"
+                }
+              ]
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], and diag[nostic]. [default: normal]"
+              ],
+              "next": [
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
           ]
         },
         {
           "name": "search",
+          "usage": [
+            "search [<TEMPLATE_NAME>]"
+          ],
           "tip": [
-            "searches for the templates supported by dotnet new on NuGet.org."
+            "Searches for the templates on NuGet.org."
+          ],
+          "option": [
+            {
+              "name": "--author",
+              "usage": [
+                "--author <AUTHOR>"
+              ],
+              "tip": [
+                "Filters the templates based on the template author."
+              ],
+              "next": []
+            },
+            {
+              "name": "--columns",
+              "usage": [
+                "--columns <AUTHOR|LANGUAGE|TAGS|TYPE>"
+              ],
+              "tip": [
+                "Specifies the columns to display in the output."
+              ],
+              "next": [
+                {
+                  "name": "author"
+                },
+                {
+                  "name": "language"
+                },
+                {
+                  "name": "tags"
+                },
+                {
+                  "name": "type"
+                }
+              ]
+            },
+            {
+              "name": "--columns-all",
+              "tip": [
+                "Displays all columns in the output."
+              ]
+            },
+            {
+              "name": "--language",
+              "alias": [
+                "-lang"
+              ],
+              "usage": [
+                "-lang, --language <LANGUAGE>"
+              ],
+              "tip": [
+                "Filters templates based on language."
+              ],
+              "next": [
+                {
+                  "name": "C#",
+                  "tip": [
+                    "C#"
+                  ]
+                },
+                {
+                  "name": "F#",
+                  "tip": [
+                    "F#"
+                  ]
+                },
+                {
+                  "name": "VB",
+                  "tip": [
+                    "Visual Basic"
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "--package",
+              "usage": [
+                "--package <PACKAGE>"
+              ],
+              "tip": [
+                "Filters the templates based on NuGet package ID."
+              ],
+              "next": []
+            },
+            {
+              "name": "--tag",
+              "usage": [
+                "--tag <TAG>"
+              ],
+              "tip": [
+                "Filters the templates based on the tag."
+              ],
+              "next": []
+            },
+            {
+              "name": "--type",
+              "usage": [
+                "--type <TYPE>"
+              ],
+              "tip": [
+                "Filters templates based on available types. Predefined values are \"project\" and \"item\"."
+              ],
+              "next": [
+                {
+                  "name": "item"
+                },
+                {
+                  "name": "project"
+                }
+              ]
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], and diag[nostic]. [default: normal]"
+              ],
+              "next": [
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
           ]
         },
         {
           "name": "uninstall",
+          "usage": [
+            "uninstall [<PACKAGE>]"
+          ],
           "tip": [
-            "uninstalls a template package."
+            "Uninstalls a template package."
+          ],
+          "option": [
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], and diag[nostic]. [default: normal]"
+              ],
+              "next": [
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
           ]
         },
         {
           "name": "update",
           "tip": [
-            "updates installed template packages."
+            "Checks the currently installed template packages for update, and install the updates."
+          ],
+          "option": [
+            {
+              "name": "--check-only",
+              "alias": [
+                "--dry-run"
+              ],
+              "usage": [
+                "--dry-run, --check-only"
+              ],
+              "tip": [
+                "Only checks for updates and display the template packages to be updated without applying update."
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+              ]
+            },
+            {
+              "name": "--nuget-source",
+              "alias": [
+                "--add-source"
+              ],
+              "usage": [
+                "--add-source, --nuget-source <NUGET_SOURCE>"
+              ],
+              "tip": [
+                "Specifies a NuGet source to use."
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], and diag[nostic]. [default: normal]"
+              ],
+              "next": [
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
           ]
         }
       ]
@@ -188,61 +2483,1058 @@
     {
       "name": "nuget",
       "tip": [
-        ".NET commands for managing NuGet package manager."
+        "Provides additional NuGet commands."
       ],
       "next": [
         {
           "name": "add",
+          "usage": [
+            "add [command]"
+          ],
           "tip": [
-            "Adds a NuGet source."
+            "Add a NuGet source."
+          ],
+          "option": [
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "Forces the application to run using an invariant, English-based culture."
+              ]
+            }
+          ],
+          "next": [
+            {
+              "name": "client-cert",
+              "tip": [
+                "Adds a client certificate configuration that matches the given package source name."
+              ]
+            },
+            {
+              "name": "source",
+              "usage": [
+                "source <PACKAGE_SOURCE_PATH>"
+              ],
+              "tip": [
+                "Add a NuGet source."
+              ],
+              "option": [
+                {
+                  "name": "--allow-insecure-connections",
+                  "tip": [
+                    "Allows HTTP connections for adding or updating packages. Note: This method is not secure."
+                  ]
+                },
+                {
+                  "name": "--configfile",
+                  "usage": [
+                    "--configfile <CONFIGFILE>"
+                  ],
+                  "tip": [
+                    "The NuGet configuration file. If specified, only the settings from this file will be used."
+                  ],
+                  "next": []
+                },
+                {
+                  "name": "--name",
+                  "alias": [
+                    "-n"
+                  ],
+                  "usage": [
+                    "-n, --name <NAME>"
+                  ],
+                  "tip": [
+                    "Name of the source."
+                  ],
+                  "next": []
+                },
+                {
+                  "name": "--password",
+                  "alias": [
+                    "-p"
+                  ],
+                  "usage": [
+                    "-p, --password <PASSWORD>"
+                  ],
+                  "tip": [
+                    "Password to be used when connecting to an authenticated source."
+                  ],
+                  "next": []
+                },
+                {
+                  "name": "--protocol-version",
+                  "usage": [
+                    "--protocol-version <VERSION>"
+                  ],
+                  "tip": [
+                    "The NuGet server protocol version to be used. Currently supported versions are 2 and 3. Defaults to 2 if not specified."
+                  ],
+                  "next": [
+                    {
+                      "name": "2",
+                      "tip": [
+                        "NuGet v2 protocol"
+                      ]
+                    },
+                    {
+                      "name": "3",
+                      "tip": [
+                        "NuGet v3 protocol"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "--store-password-in-clear-text",
+                  "tip": [
+                    "Enables storing portable package source credentials by disabling password encryption."
+                  ]
+                },
+                {
+                  "name": "--username",
+                  "alias": [
+                    "-u"
+                  ],
+                  "usage": [
+                    "-u, --username <USERNAME>"
+                  ],
+                  "tip": [
+                    "Username to be used when connecting to an authenticated source."
+                  ],
+                  "next": []
+                },
+                {
+                  "name": "--valid-authentication-types",
+                  "usage": [
+                    "--valid-authentication-types <TYPES>"
+                  ],
+                  "tip": [
+                    "Comma-separated list of valid authentication types for this source. Set this to basic if the server advertises NTLM or Negotiate and your credentials must be sent using the Basic mechanism."
+                  ],
+                  "next": [
+                    {
+                      "name": "basic",
+                      "tip": [
+                        "Basic authentication"
+                      ]
+                    },
+                    {
+                      "name": "digest",
+                      "tip": [
+                        "Digest authentication"
+                      ]
+                    },
+                    {
+                      "name": "kerberos",
+                      "tip": [
+                        "Kerberos authentication"
+                      ]
+                    },
+                    {
+                      "name": "negotiate",
+                      "tip": [
+                        "Negotiate authentication"
+                      ]
+                    },
+                    {
+                      "name": "ntlm",
+                      "tip": [
+                        "NTLM authentication"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "config",
+          "usage": [
+            "config [command]"
+          ],
+          "tip": [
+            "NuGet configuration CLI."
+          ],
+          "option": [
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "Forces the application to run using an invariant, English-based culture."
+              ]
+            }
+          ],
+          "next": [
+            {
+              "name": "get",
+              "usage": [
+                "get <ALL_OR_CONFIG_KEY>"
+              ],
+              "tip": [
+                "Gets the NuGet configuration settings that will be applied."
+              ]
+            },
+            {
+              "name": "paths",
+              "tip": [
+                "Lists the paths to all NuGet configuration files that will be applied when invoking NuGet command in a specific directory."
+              ]
+            },
+            {
+              "name": "set",
+              "usage": [
+                "set <CONFIG_KEY> <CONFIG_VALUE>"
+              ],
+              "tip": [
+                "Set the value of a specified NuGet configuration setting."
+              ]
+            },
+            {
+              "name": "unset",
+              "usage": [
+                "unset <CONFIG_KEY>"
+              ],
+              "tip": [
+                "Removes the key-value pair from a specified NuGet configuration setting."
+              ]
+            }
           ]
         },
         {
           "name": "delete",
+          "usage": [
+            "delete <PACKAGE_ID> <PACKAGE_VERSION>"
+          ],
           "tip": [
-            "Deletes or unlists a package from the server."
+            "Deletes a package from the server."
+          ],
+          "option": [
+            {
+              "name": "--api-key",
+              "alias": [
+                "-k"
+              ],
+              "usage": [
+                "-k, --api-key <API_KEY>"
+              ],
+              "tip": [
+                "The API key for the server. If not set, the NUGET_API_KEY environment variable is read."
+              ],
+              "next": []
+            },
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "Forces the application to run using an invariant, English-based culture."
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "Allow the command to block and require manual action for operations like authentication."
+              ]
+            },
+            {
+              "name": "--no-service-endpoint",
+              "tip": [
+                "Does not append \"api/v2/package\" to the source URL."
+              ]
+            },
+            {
+              "name": "--non-interactive",
+              "tip": [
+                "Do not prompt for user input or confirmations."
+              ]
+            },
+            {
+              "name": "--source",
+              "alias": [
+                "-s"
+              ],
+              "usage": [
+                "-s, --source <SOURCE>"
+              ],
+              "tip": [
+                "Package source (URL, UNC/folder path or package source name) to use. Defaults to DefaultPushSource if specified in NuGet.Config."
+              ],
+              "next": []
+            }
           ]
         },
         {
           "name": "disable",
+          "usage": [
+            "disable [command]"
+          ],
           "tip": [
-            "Disables a NuGet source."
+            "Disable a NuGet source."
+          ],
+          "option": [
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "Forces the application to run using an invariant, English-based culture."
+              ]
+            }
+          ],
+          "next": [
+            {
+              "name": "source",
+              "usage": [
+                "source <NAME>"
+              ],
+              "tip": [
+                "Disable a NuGet source."
+              ]
+            }
           ]
         },
         {
           "name": "enable",
+          "usage": [
+            "enable [command]"
+          ],
           "tip": [
-            "Enables a NuGet source."
+            "Enable a NuGet source."
+          ],
+          "option": [
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "Forces the application to run using an invariant, English-based culture."
+              ]
+            }
+          ],
+          "next": [
+            {
+              "name": "source",
+              "usage": [
+                "source <NAME>"
+              ],
+              "tip": [
+                "Enable a NuGet source."
+              ]
+            }
           ]
         },
         {
           "name": "list",
+          "usage": [
+            "list [command]"
+          ],
           "tip": [
-            "Lists all configured NuGet sources."
+            "List configured NuGet sources."
+          ],
+          "option": [
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "Forces the application to run using an invariant, English-based culture."
+              ]
+            }
+          ],
+          "next": [
+            {
+              "name": "client-cert",
+              "tip": [
+                "Lists all the client certificates in the configuration."
+              ]
+            },
+            {
+              "name": "source",
+              "tip": [
+                "Lists all configured NuGet sources."
+              ]
+            }
           ]
         },
         {
           "name": "locals",
+          "usage": [
+            "locals [<CACHE_LOCATION(S)>]"
+          ],
           "tip": [
-            "Clears or lists local NuGet resources such as http-request cache, temporary cache, or machine-wide global packages folder."
+            "Clears or lists local NuGet resources such as http requests cache, packages folder, plugin operations cache or machine-wide global packages folder."
+          ],
+          "option": [
+            {
+              "name": "--clear",
+              "alias": [
+                "-c"
+              ],
+              "usage": [
+                "-c, --clear"
+              ],
+              "tip": [
+                "Clear the selected local resources or cache location(s)."
+              ]
+            },
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "Forces the application to run using an invariant, English-based culture."
+              ]
+            },
+            {
+              "name": "--list",
+              "alias": [
+                "-l"
+              ],
+              "usage": [
+                "-l, --list"
+              ],
+              "tip": [
+                "List the selected local resources or cache location(s)."
+              ]
+            }
+          ],
+          "next": [
+            {
+              "name": "all",
+              "tip": [
+                "All local NuGet resources."
+              ]
+            },
+            {
+              "name": "global-packages",
+              "tip": [
+                "The machine-wide global packages folder."
+              ]
+            },
+            {
+              "name": "http-cache",
+              "tip": [
+                "The HTTP cache."
+              ]
+            },
+            {
+              "name": "temp",
+              "tip": [
+                "The temporary cache."
+              ]
+            }
           ]
         },
         {
           "name": "push",
+          "usage": [
+            "push <PACKAGE_PATHS>"
+          ],
           "tip": [
             "Pushes a package to the server and publishes it."
+          ],
+          "option": [
+            {
+              "name": "--allow-insecure-connections",
+              "tip": [
+                "Allows pushing to HTTP sources (insecure)."
+              ]
+            },
+            {
+              "name": "--api-key",
+              "alias": [
+                "-k"
+              ],
+              "usage": [
+                "-k, --api-key <API_KEY>"
+              ],
+              "tip": [
+                "The API key for the server. If not set, the NUGET_API_KEY environment variable is read."
+              ],
+              "next": []
+            },
+            {
+              "name": "--configfile",
+              "usage": [
+                "--configfile <CONFIGFILE>"
+              ],
+              "tip": [
+                "The NuGet configuration file. If specified, only the settings from this file will be used."
+              ],
+              "next": []
+            },
+            {
+              "name": "--disable-buffering",
+              "alias": [
+                "-d"
+              ],
+              "usage": [
+                "-d, --disable-buffering"
+              ],
+              "tip": [
+                "Disable buffering when pushing to an HTTP(S) server to decrease memory usage."
+              ]
+            },
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "Forces the application to run using an invariant, English-based culture."
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "Allow the command to block and require manual action for operations like authentication."
+              ]
+            },
+            {
+              "name": "--no-service-endpoint",
+              "tip": [
+                "Does not append \"api/v2/package\" to the source URL."
+              ]
+            },
+            {
+              "name": "--no-symbols",
+              "alias": [
+                "-n"
+              ],
+              "usage": [
+                "-n, --no-symbols"
+              ],
+              "tip": [
+                "If a symbols package exists, it will not be pushed to a symbols server."
+              ]
+            },
+            {
+              "name": "--skip-duplicate",
+              "tip": [
+                "If a package and version already exists, skip it and continue with the next package in the push, if any."
+              ]
+            },
+            {
+              "name": "--source",
+              "alias": [
+                "-s"
+              ],
+              "usage": [
+                "-s, --source <SOURCE>"
+              ],
+              "tip": [
+                "Package source (URL, UNC/folder path or package source name) to use. Defaults to DefaultPushSource if specified in NuGet.Config."
+              ],
+              "next": []
+            },
+            {
+              "name": "--symbol-api-key",
+              "alias": [
+                "-sk"
+              ],
+              "usage": [
+                "-sk, --symbol-api-key <SYMBOL_API_KEY>"
+              ],
+              "tip": [
+                "The API key for the symbol server. If not set, the NUGET_SYMBOL_API_KEY environment variable is read."
+              ],
+              "next": []
+            },
+            {
+              "name": "--symbol-source",
+              "alias": [
+                "-ss"
+              ],
+              "usage": [
+                "-ss, --symbol-source <SYMBOL_SOURCE>"
+              ],
+              "tip": [
+                "Symbol server URL to use."
+              ],
+              "next": []
+            },
+            {
+              "name": "--timeout",
+              "alias": [
+                "-t"
+              ],
+              "usage": [
+                "-t, --timeout <TIMEOUT>"
+              ],
+              "tip": [
+                "Timeout for pushing to a server in seconds. Defaults to 300 seconds (5 minutes)."
+              ],
+              "next": []
+            }
           ]
         },
         {
           "name": "remove",
+          "usage": [
+            "remove [command]"
+          ],
           "tip": [
-            "Removes a NuGet source."
+            "Remove a NuGet source."
+          ],
+          "option": [
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "Forces the application to run using an invariant, English-based culture."
+              ]
+            }
+          ],
+          "next": [
+            {
+              "name": "client-cert",
+              "tip": [
+                "Removes the client certificate configuration that matches the given package source name."
+              ]
+            },
+            {
+              "name": "source",
+              "usage": [
+                "source <NAME>"
+              ],
+              "tip": [
+                "Remove a NuGet source."
+              ]
+            }
+          ]
+        },
+        {
+          "name": "sign",
+          "usage": [
+            "sign <PACKAGE_PATHS>"
+          ],
+          "tip": [
+            "Signs NuGet package(s) at <package-paths> with the specified certificate."
+          ],
+          "option": [
+            {
+              "name": "--allow-untrusted-root",
+              "tip": [
+                "Allow signing with certificates whose root certificate is not in a trusted root store."
+              ]
+            },
+            {
+              "name": "--certificate-fingerprint",
+              "usage": [
+                "--certificate-fingerprint <FINGERPRINT>"
+              ],
+              "tip": [
+                "SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate."
+              ],
+              "next": []
+            },
+            {
+              "name": "--certificate-password",
+              "usage": [
+                "--certificate-password <PASSWORD>"
+              ],
+              "tip": [
+                "Password for the certificate, if needed."
+              ],
+              "next": []
+            },
+            {
+              "name": "--certificate-path",
+              "usage": [
+                "--certificate-path <PATH>"
+              ],
+              "tip": [
+                "File path to the certificate to be used while signing the package."
+              ],
+              "next": []
+            },
+            {
+              "name": "--certificate-store-location",
+              "usage": [
+                "--certificate-store-location <LOCATION>"
+              ],
+              "tip": [
+                "Name of the X.509 certificate store used to search for the certificate. Defaults to \"CurrentUser\"."
+              ],
+              "next": []
+            },
+            {
+              "name": "--certificate-store-name",
+              "usage": [
+                "--certificate-store-name <NAME>"
+              ],
+              "tip": [
+                "Name of the X.509 certificate store to use to search for the certificate. Defaults to \"My\"."
+              ],
+              "next": []
+            },
+            {
+              "name": "--certificate-subject-name",
+              "usage": [
+                "--certificate-subject-name <NAME>"
+              ],
+              "tip": [
+                "Subject name of the certificate used to search a local certificate store for the certificate."
+              ],
+              "next": []
+            },
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "Forces the application to run using an invariant, English-based culture."
+              ]
+            },
+            {
+              "name": "--hash-algorithm",
+              "usage": [
+                "--hash-algorithm <ALGORITHM>"
+              ],
+              "tip": [
+                "Hash algorithm to be used to sign the package. Defaults to SHA256."
+              ],
+              "next": [
+                {
+                  "name": "SHA256",
+                  "tip": [
+                    "SHA-256"
+                  ]
+                },
+                {
+                  "name": "SHA384",
+                  "tip": [
+                    "SHA-384"
+                  ]
+                },
+                {
+                  "name": "SHA512",
+                  "tip": [
+                    "SHA-512"
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "--output",
+              "alias": [
+                "-o"
+              ],
+              "usage": [
+                "-o, --output <OUTPUT>"
+              ],
+              "tip": [
+                "Directory where the signed package(s) should be saved. By default the original package is overwritten by the signed package."
+              ],
+              "next": []
+            },
+            {
+              "name": "--overwrite",
+              "tip": [
+                "Switch to indicate if the current signature should be overwritten. By default the command will fail if the package already has a signature."
+              ]
+            },
+            {
+              "name": "--timestamp-hash-algorithm",
+              "usage": [
+                "--timestamp-hash-algorithm <ALGORITHM>"
+              ],
+              "tip": [
+                "Hash algorithm to be used by the RFC 3161 timestamp server. Defaults to SHA256."
+              ],
+              "next": [
+                {
+                  "name": "SHA256",
+                  "tip": [
+                    "SHA-256"
+                  ]
+                },
+                {
+                  "name": "SHA384",
+                  "tip": [
+                    "SHA-384"
+                  ]
+                },
+                {
+                  "name": "SHA512",
+                  "tip": [
+                    "SHA-512"
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "--timestamper",
+              "usage": [
+                "--timestamper <URL>"
+              ],
+              "tip": [
+                "URL to an RFC 3161 timestamping server."
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]."
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "trust",
+          "usage": [
+            "trust [command]"
+          ],
+          "tip": [
+            "Manage the trusted signers."
+          ],
+          "option": [
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "Forces the application to run using an invariant, English-based culture."
+              ]
+            }
+          ],
+          "next": [
+            {
+              "name": "author",
+              "usage": [
+                "author <NAME> <PACKAGE>"
+              ],
+              "tip": [
+                "Adds a trusted signer with the given name, based on the author signature of the package."
+              ]
+            },
+            {
+              "name": "certificate",
+              "usage": [
+                "certificate <NAME> <FINGERPRINT>"
+              ],
+              "tip": [
+                "Adds a trusted signer with the given name, based on the repository signature or countersignature of a signed package."
+              ]
+            },
+            {
+              "name": "list",
+              "tip": [
+                "Lists all the trusted signers in the configuration."
+              ]
+            },
+            {
+              "name": "remove",
+              "usage": [
+                "remove <NAME>"
+              ],
+              "tip": [
+                "Removes any trusted signers that match the given name."
+              ]
+            },
+            {
+              "name": "repository",
+              "usage": [
+                "repository <NAME> <PACKAGE>"
+              ],
+              "tip": [
+                "Adds a trusted signer with the given name, based on the repository signature or countersignature of a signed package."
+              ]
+            },
+            {
+              "name": "source",
+              "usage": [
+                "source <NAME>"
+              ],
+              "tip": [
+                "Adds a trusted signer based on a given package source."
+              ],
+              "option": [
+                {
+                  "name": "--owners",
+                  "usage": [
+                    "--owners <OWNERS>"
+                  ],
+                  "tip": [
+                    "Semi-colon separated list of trusted owners to further restrict the trust of a repository."
+                  ],
+                  "next": []
+                },
+                {
+                  "name": "--source-url",
+                  "usage": [
+                    "--source-url <URL>"
+                  ],
+                  "tip": [
+                    "If a source-url is provided, it must be a v3 package source URL (like https://api.nuget.org/v3/index.json). Other package source types are not supported."
+                  ],
+                  "next": []
+                }
+              ]
+            },
+            {
+              "name": "sync",
+              "usage": [
+                "sync <NAME>"
+              ],
+              "tip": [
+                "Deletes the current list of certificates and replaces them with an up-to-date list from the repository."
+              ]
+            }
           ]
         },
         {
           "name": "update",
+          "usage": [
+            "update [command]"
+          ],
           "tip": [
-            "Updates a NuGet source."
+            "Update a NuGet source."
+          ],
+          "option": [
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "Forces the application to run using an invariant, English-based culture."
+              ]
+            }
+          ],
+          "next": [
+            {
+              "name": "client-cert",
+              "tip": [
+                "Updates the client certificate configuration that matches the given package source name."
+              ]
+            },
+            {
+              "name": "source",
+              "usage": [
+                "source <NAME>"
+              ],
+              "tip": [
+                "Update a NuGet source."
+              ]
+            }
+          ]
+        },
+        {
+          "name": "verify",
+          "usage": [
+            "verify <PACKAGE_PATHS>"
+          ],
+          "tip": [
+            "Verifies a signed NuGet package."
+          ],
+          "option": [
+            {
+              "name": "--all",
+              "tip": [
+                "Specifies that all verifications possible should be performed to the package(s)."
+              ]
+            },
+            {
+              "name": "--certificate-fingerprint",
+              "usage": [
+                "--certificate-fingerprint <FINGERPRINT>"
+              ],
+              "tip": [
+                "Verify that the signer certificate matches with one of the specified SHA256 fingerprints. Multiple inputs should be separated by space."
+              ],
+              "next": []
+            },
+            {
+              "name": "--configfile",
+              "usage": [
+                "--configfile <CONFIGFILE>"
+              ],
+              "tip": [
+                "The NuGet configuration file. If specified, only the settings from this file will be used."
+              ],
+              "next": []
+            },
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "Forces the application to run using an invariant, English-based culture."
+              ]
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]."
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "why",
+          "usage": [
+            "why <PROJECT | SOLUTION | FILE> <PACKAGE>"
+          ],
+          "tip": [
+            "Shows the dependency graph for a particular package for a given project or solution."
+          ],
+          "option": [
+            {
+              "name": "--framework",
+              "alias": [
+                "-f"
+              ],
+              "usage": [
+                "-f, --framework <FRAMEWORK>"
+              ],
+              "tip": [
+                "The target framework(s) for which dependency graphs are shown."
+              ],
+              "next": [
+                {
+                  "name": "net10.0",
+                  "tip": [
+                    ".NET 10"
+                  ]
+                },
+                {
+                  "name": "net8.0",
+                  "tip": [
+                    ".NET 8"
+                  ]
+                },
+                {
+                  "name": "net9.0",
+                  "tip": [
+                    ".NET 9"
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
@@ -250,37 +3542,835 @@
     {
       "name": "pack",
       "tip": [
-        "Creates a NuGet package of your code."
+        "Create a NuGet package."
+      ],
+      "option": [
+        {
+          "name": "--artifacts-path",
+          "usage": [
+            "--artifacts-path <ARTIFACTS_DIR>"
+          ],
+          "tip": [
+            "The artifacts path. All output from the project, including build, publish, and pack output, will go in subfolders under the specified path."
+          ],
+          "next": []
+        },
+        {
+          "name": "--configuration",
+          "alias": [
+            "-c"
+          ],
+          "usage": [
+            "-c, --configuration <CONFIGURATION>"
+          ],
+          "tip": [
+            "The configuration to use for building the package. The default is 'Release'."
+          ],
+          "next": [
+            {
+              "name": "Debug"
+            },
+            {
+              "name": "Release"
+            }
+          ]
+        },
+        {
+          "name": "--disable-build-servers",
+          "tip": [
+            "Force the command to ignore any persistent build servers."
+          ]
+        },
+        {
+          "name": "--include-source",
+          "tip": [
+            "Include PDBs and source files. Source files go into the 'src' folder in the resulting nuget package."
+          ]
+        },
+        {
+          "name": "--include-symbols",
+          "tip": [
+            "Include packages with symbols in addition to regular packages in output directory."
+          ]
+        },
+        {
+          "name": "--interactive",
+          "tip": [
+            "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+          ]
+        },
+        {
+          "name": "--no-build",
+          "tip": [
+            "Do not build the project before packing. Implies --no-restore."
+          ]
+        },
+        {
+          "name": "--no-logo",
+          "alias": [
+            "-nologo"
+          ],
+          "usage": [
+            "-nologo, --no-logo"
+          ],
+          "tip": [
+            "Do not display the startup banner or the copyright message."
+          ]
+        },
+        {
+          "name": "--no-restore",
+          "tip": [
+            "Do not restore the project before building."
+          ]
+        },
+        {
+          "name": "--output",
+          "alias": [
+            "-o"
+          ],
+          "usage": [
+            "-o, --output <OUTPUT_DIR>"
+          ],
+          "tip": [
+            "The output directory to place built packages in."
+          ],
+          "next": []
+        },
+        {
+          "name": "--runtime",
+          "alias": [
+            "-r"
+          ],
+          "usage": [
+            "-r, --runtime <RUNTIME_IDENTIFIER>"
+          ],
+          "tip": [
+            "The target runtime to build for."
+          ],
+          "next": [
+            {
+              "name": "linux-x64",
+              "tip": [
+                "Linux x64"
+              ]
+            },
+            {
+              "name": "osx-arm64",
+              "tip": [
+                "macOS ARM64"
+              ]
+            },
+            {
+              "name": "win-x64",
+              "tip": [
+                "Windows x64"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--serviceable",
+          "alias": [
+            "-s"
+          ],
+          "usage": [
+            "-s, --serviceable"
+          ],
+          "tip": [
+            "Set the serviceable flag in the package."
+          ]
+        },
+        {
+          "name": "--use-current-runtime",
+          "alias": [
+            "--ucr"
+          ],
+          "usage": [
+            "--ucr, --use-current-runtime"
+          ],
+          "tip": [
+            "Use current runtime as the target runtime."
+          ]
+        },
+        {
+          "name": "--verbosity",
+          "alias": [
+            "-verbosity",
+            "-v"
+          ],
+          "usage": [
+            "-v, -verbosity, --verbosity <LEVEL>"
+          ],
+          "tip": [
+            "Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]."
+          ],
+          "next": [
+            {
+              "name": "detailed"
+            },
+            {
+              "name": "diagnostic"
+            },
+            {
+              "name": "minimal"
+            },
+            {
+              "name": "normal"
+            },
+            {
+              "name": "quiet"
+            }
+          ]
+        },
+        {
+          "name": "--version",
+          "usage": [
+            "--version <VERSION>"
+          ],
+          "tip": [
+            "The version of the package to create."
+          ],
+          "next": []
+        },
+        {
+          "name": "--version-suffix",
+          "usage": [
+            "--version-suffix <VERSION_SUFFIX>"
+          ],
+          "tip": [
+            "Set the value of the $(VersionSuffix) property to use when building the project."
+          ],
+          "next": []
+        }
       ]
     },
     {
       "name": "package",
       "tip": [
-        ".NET commands for managing NuGet package."
+        "Search for, add, remove, or list PackageReferences for a .NET project."
       ],
       "next": [
         {
           "name": "add",
+          "usage": [
+            "add <PACKAGE_ID>"
+          ],
           "tip": [
-            "Adds a NuGet package."
+            "Add a NuGet package reference to the project."
+          ],
+          "option": [
+            {
+              "name": "--file",
+              "usage": [
+                "--file <FILE>"
+              ],
+              "tip": [
+                "The file-based app to operate on."
+              ],
+              "next": []
+            },
+            {
+              "name": "--framework",
+              "alias": [
+                "-f"
+              ],
+              "usage": [
+                "-f, --framework <FRAMEWORK>"
+              ],
+              "tip": [
+                "Add the reference only when targeting a specific framework."
+              ],
+              "next": [
+                {
+                  "name": "net10.0",
+                  "tip": [
+                    ".NET 10"
+                  ]
+                },
+                {
+                  "name": "net8.0",
+                  "tip": [
+                    ".NET 8"
+                  ]
+                },
+                {
+                  "name": "net9.0",
+                  "tip": [
+                    ".NET 9"
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+              ]
+            },
+            {
+              "name": "--no-restore",
+              "alias": [
+                "-n"
+              ],
+              "usage": [
+                "-n, --no-restore"
+              ],
+              "tip": [
+                "Add the reference without performing restore preview and compatibility check."
+              ]
+            },
+            {
+              "name": "--package-directory",
+              "usage": [
+                "--package-directory <PACKAGE_DIR>"
+              ],
+              "tip": [
+                "The directory to restore packages to."
+              ],
+              "next": []
+            },
+            {
+              "name": "--prerelease",
+              "tip": [
+                "Allows prerelease packages to be installed."
+              ]
+            },
+            {
+              "name": "--project",
+              "usage": [
+                "--project <PROJECT>"
+              ],
+              "tip": [
+                "The project file to operate on. If a file is not specified, the command will search the current directory for one."
+              ],
+              "next": []
+            },
+            {
+              "name": "--source",
+              "alias": [
+                "-s"
+              ],
+              "usage": [
+                "-s, --source <SOURCE>"
+              ],
+              "tip": [
+                "The NuGet package source to use during the restore."
+              ],
+              "next": []
+            },
+            {
+              "name": "--version",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --version <VERSION>"
+              ],
+              "tip": [
+                "The version of the package to add."
+              ],
+              "next": []
+            }
+          ]
+        },
+        {
+          "name": "download",
+          "usage": [
+            "download <PACKAGES>"
+          ],
+          "tip": [
+            "Downloads a NuGet package to a local folder without requiring a project file."
+          ],
+          "option": [
+            {
+              "name": "--allow-insecure-connections",
+              "tip": [
+                "Allows downloading from HTTP (non-HTTPS) package sources."
+              ]
+            },
+            {
+              "name": "--configfile",
+              "usage": [
+                "--configfile <CONFIGFILE>"
+              ],
+              "tip": [
+                "The NuGet configuration file. If specified, only the settings from this file will be used."
+              ],
+              "next": []
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+              ]
+            },
+            {
+              "name": "--output",
+              "alias": [
+                "-o"
+              ],
+              "usage": [
+                "-o, --output <OUTPUT>"
+              ],
+              "tip": [
+                "Directory where the package will be placed. Defaults to the current working directory."
+              ],
+              "next": []
+            },
+            {
+              "name": "--prerelease",
+              "tip": [
+                "Allows prerelease packages to be installed."
+              ]
+            },
+            {
+              "name": "--source",
+              "alias": [
+                "-s"
+              ],
+              "usage": [
+                "-s, --source <SOURCE>"
+              ],
+              "tip": [
+                "Specifies one or more NuGet package sources to use."
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]."
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
           ]
         },
         {
           "name": "list",
           "tip": [
-            "Lists NuGet packages."
+            "List all package references of the project or solution."
+          ],
+          "option": [
+            {
+              "name": "--configfile",
+              "alias": [
+                "--config"
+              ],
+              "usage": [
+                "--config, --configfile <CONFIG_FILE>"
+              ],
+              "tip": [
+                "The path to the NuGet config file to use. Requires the '--outdated', '--deprecated' or '--vulnerable' option."
+              ],
+              "next": []
+            },
+            {
+              "name": "--deprecated",
+              "tip": [
+                "Lists packages that have been deprecated. Cannot be combined with '--vulnerable' or '--outdated' options."
+              ]
+            },
+            {
+              "name": "--file",
+              "usage": [
+                "--file <FILE>"
+              ],
+              "tip": [
+                "The file-based app to operate on."
+              ],
+              "next": []
+            },
+            {
+              "name": "--format",
+              "usage": [
+                "--format <CONSOLE|JSON>"
+              ],
+              "tip": [
+                "Specifies the output format type for the list packages command."
+              ],
+              "next": [
+                {
+                  "name": "console"
+                },
+                {
+                  "name": "json"
+                }
+              ]
+            },
+            {
+              "name": "--framework",
+              "alias": [
+                "-f"
+              ],
+              "usage": [
+                "-f, --framework <FRAMEWORK | FRAMEWORK\\RID>"
+              ],
+              "tip": [
+                "Chooses a framework to show its packages. Use the option multiple times for multiple frameworks."
+              ],
+              "repeat": 99,
+              "next": [
+                {
+                  "name": "net10.0",
+                  "tip": [
+                    ".NET 10"
+                  ]
+                },
+                {
+                  "name": "net8.0",
+                  "tip": [
+                    ".NET 8"
+                  ]
+                },
+                {
+                  "name": "net9.0",
+                  "tip": [
+                    ".NET 9"
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "--highest-minor",
+              "tip": [
+                "Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option."
+              ]
+            },
+            {
+              "name": "--highest-patch",
+              "tip": [
+                "Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option."
+              ]
+            },
+            {
+              "name": "--include-prerelease",
+              "tip": [
+                "Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option."
+              ]
+            },
+            {
+              "name": "--include-transitive",
+              "tip": [
+                "Lists transitive and top-level packages."
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+              ]
+            },
+            {
+              "name": "--no-restore",
+              "tip": [
+                "Do not restore before running the command."
+              ]
+            },
+            {
+              "name": "--outdated",
+              "tip": [
+                "Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options."
+              ]
+            },
+            {
+              "name": "--output-version",
+              "usage": [
+                "--output-version <OUTPUT_VERSION>"
+              ],
+              "tip": [
+                "Specifies the version of machine-readable output. Requires the '--format json' option."
+              ],
+              "next": []
+            },
+            {
+              "name": "--project",
+              "usage": [
+                "--project <PROJECT>"
+              ],
+              "tip": [
+                "The project file to operate on. If a file is not specified, the command will search the current directory for one."
+              ],
+              "next": []
+            },
+            {
+              "name": "--source",
+              "alias": [
+                "-s"
+              ],
+              "usage": [
+                "-s, --source <SOURCE>"
+              ],
+              "tip": [
+                "The NuGet sources to use when searching for newer packages. Requires the '--outdated', '--deprecated' or '--vulnerable' option."
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]."
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            },
+            {
+              "name": "--vulnerable",
+              "tip": [
+                "Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options."
+              ]
+            }
           ]
         },
         {
           "name": "remove",
+          "usage": [
+            "remove <PACKAGE_NAME>"
+          ],
           "tip": [
-            "Removes a NuGet package."
+            "Remove a NuGet package reference from the project."
+          ],
+          "option": [
+            {
+              "name": "--file",
+              "usage": [
+                "--file <FILE>"
+              ],
+              "tip": [
+                "The file-based app to operate on."
+              ],
+              "next": []
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+              ]
+            },
+            {
+              "name": "--project",
+              "usage": [
+                "--project <PROJECT>"
+              ],
+              "tip": [
+                "The project file to operate on. If a file is not specified, the command will search the current directory for one."
+              ],
+              "next": []
+            }
           ]
         },
         {
           "name": "search",
+          "usage": [
+            "search [<SEARCH_TERM>]"
+          ],
           "tip": [
-            "Searches for a NuGet package."
+            "Searches one or more package sources for packages that match a search term. If no sources are specified, all sources defined in the NuGet.Config are used."
+          ],
+          "option": [
+            {
+              "name": "--configfile",
+              "usage": [
+                "--configfile <CONFIG_FILE>"
+              ],
+              "tip": [
+                "The NuGet configuration file. If specified, only the settings from this file will be used."
+              ],
+              "next": []
+            },
+            {
+              "name": "--exact-match",
+              "tip": [
+                "Require that the search term exactly match the name of the package. Causes `--take` and `--skip` options to be ignored."
+              ]
+            },
+            {
+              "name": "--format",
+              "usage": [
+                "--format <TABLE|JSON>"
+              ],
+              "tip": [
+                "Format the output accordingly. Either `table`, or `json`. The default value is `table`."
+              ],
+              "next": [
+                {
+                  "name": "json"
+                },
+                {
+                  "name": "table"
+                }
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+              ]
+            },
+            {
+              "name": "--prerelease",
+              "tip": [
+                "Include prerelease packages."
+              ]
+            },
+            {
+              "name": "--skip",
+              "usage": [
+                "--skip <SKIP>"
+              ],
+              "tip": [
+                "Number of results to skip, to allow pagination. Default 0."
+              ],
+              "next": []
+            },
+            {
+              "name": "--source",
+              "usage": [
+                "--source <SOURCE>"
+              ],
+              "tip": [
+                "The package source to search. You can pass multiple `--source` options to search multiple package sources."
+              ],
+              "repeat": 99,
+              "next": []
+            },
+            {
+              "name": "--take",
+              "usage": [
+                "--take <TAKE>"
+              ],
+              "tip": [
+                "Number of results to return. Default 20."
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "usage": [
+                "--verbosity <LEVEL>"
+              ],
+              "tip": [
+                "Display this amount of details in the output: `normal`, `minimal`, `detailed`. The default is `normal`."
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "update",
+          "usage": [
+            "update [<PACKAGES>]"
+          ],
+          "tip": [
+            "Update referenced packages in a project or solution."
+          ],
+          "option": [
+            {
+              "name": "--interactive",
+              "tip": [
+                "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+              ]
+            },
+            {
+              "name": "--project",
+              "alias": [
+                "--file"
+              ],
+              "usage": [
+                "--file, --project <PROJECT>"
+              ],
+              "tip": [
+                "Path to a project or solution file or file-based app, or a project directory."
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]."
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            },
+            {
+              "name": "--vulnerable",
+              "tip": [
+                "Upgrade packages with known vulnerabilities."
+              ]
+            }
           ]
         }
       ]
@@ -288,31 +4378,498 @@
     {
       "name": "publish",
       "tip": [
-        "Publishes a .NET framework-dependent or self-contained application."
+        "Publish a .NET project for deployment."
+      ],
+      "option": [
+        {
+          "name": "--arch",
+          "alias": [
+            "-a"
+          ],
+          "usage": [
+            "-a, --arch <ARCH>"
+          ],
+          "tip": [
+            "The target architecture."
+          ],
+          "next": [
+            {
+              "name": "arm",
+              "tip": [
+                "ARM32"
+              ]
+            },
+            {
+              "name": "arm64",
+              "tip": [
+                "ARM64"
+              ]
+            },
+            {
+              "name": "x64",
+              "tip": [
+                "64-bit x86"
+              ]
+            },
+            {
+              "name": "x86",
+              "tip": [
+                "32-bit x86"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--artifacts-path",
+          "usage": [
+            "--artifacts-path <ARTIFACTS_DIR>"
+          ],
+          "tip": [
+            "The artifacts path. All output from the project, including build, publish, and pack output, will go in subfolders under the specified path."
+          ],
+          "next": []
+        },
+        {
+          "name": "--configuration",
+          "alias": [
+            "-c"
+          ],
+          "usage": [
+            "-c, --configuration <CONFIGURATION>"
+          ],
+          "tip": [
+            "The configuration to publish for. The default is 'Release' for NET 8.0 projects and above, but 'Debug' for older projects."
+          ],
+          "next": [
+            {
+              "name": "Debug"
+            },
+            {
+              "name": "Release"
+            }
+          ]
+        },
+        {
+          "name": "--disable-build-servers",
+          "tip": [
+            "Force the command to ignore any persistent build servers."
+          ]
+        },
+        {
+          "name": "--framework",
+          "alias": [
+            "-f"
+          ],
+          "usage": [
+            "-f, --framework <FRAMEWORK>"
+          ],
+          "tip": [
+            "The target framework to publish for. The target framework has to be specified in the project file."
+          ],
+          "next": [
+            {
+              "name": "net10.0",
+              "tip": [
+                ".NET 10"
+              ]
+            },
+            {
+              "name": "net8.0",
+              "tip": [
+                ".NET 8"
+              ]
+            },
+            {
+              "name": "net9.0",
+              "tip": [
+                ".NET 9"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--interactive",
+          "tip": [
+            "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+          ]
+        },
+        {
+          "name": "--manifest",
+          "usage": [
+            "--manifest <MANIFEST>"
+          ],
+          "tip": [
+            "The path to a target manifest file that contains the list of packages to be excluded from the publish step."
+          ],
+          "repeat": 99,
+          "next": []
+        },
+        {
+          "name": "--no-build",
+          "tip": [
+            "Do not build the project before publishing. Implies --no-restore."
+          ]
+        },
+        {
+          "name": "--no-logo",
+          "alias": [
+            "-nologo"
+          ],
+          "usage": [
+            "-nologo, --no-logo"
+          ],
+          "tip": [
+            "Do not display the startup banner or the copyright message."
+          ]
+        },
+        {
+          "name": "--no-restore",
+          "tip": [
+            "Do not restore the project before building."
+          ]
+        },
+        {
+          "name": "--no-self-contained",
+          "tip": [
+            "Publish your application as a framework dependent application. A compatible .NET runtime must be installed on the target machine to run your application."
+          ]
+        },
+        {
+          "name": "--os",
+          "usage": [
+            "--os <OS>"
+          ],
+          "tip": [
+            "The target operating system."
+          ],
+          "next": [
+            {
+              "name": "linux",
+              "tip": [
+                "Linux"
+              ]
+            },
+            {
+              "name": "osx",
+              "tip": [
+                "macOS"
+              ]
+            },
+            {
+              "name": "win",
+              "tip": [
+                "Windows"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--output",
+          "alias": [
+            "-o"
+          ],
+          "usage": [
+            "-o, --output <OUTPUT_DIR>"
+          ],
+          "tip": [
+            "The output directory to place the published artifacts in."
+          ],
+          "next": []
+        },
+        {
+          "name": "--runtime",
+          "alias": [
+            "-r"
+          ],
+          "usage": [
+            "-r, --runtime <RUNTIME_IDENTIFIER>"
+          ],
+          "tip": [
+            "The target runtime to publish for. This is used when creating a self-contained deployment.",
+            "The default is to publish a framework-dependent application."
+          ],
+          "next": [
+            {
+              "name": "linux-arm64",
+              "tip": [
+                "Linux ARM64"
+              ]
+            },
+            {
+              "name": "linux-x64",
+              "tip": [
+                "Linux x64"
+              ]
+            },
+            {
+              "name": "osx-arm64",
+              "tip": [
+                "macOS ARM64"
+              ]
+            },
+            {
+              "name": "osx-x64",
+              "tip": [
+                "macOS x64"
+              ]
+            },
+            {
+              "name": "win-x64",
+              "tip": [
+                "Windows x64"
+              ]
+            },
+            {
+              "name": "win-x86",
+              "tip": [
+                "Windows x86"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--self-contained",
+          "alias": [
+            "--sc"
+          ],
+          "usage": [
+            "--sc, --self-contained"
+          ],
+          "tip": [
+            "Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.",
+            "The default is 'false.' However, when targeting .NET 7 or lower, the default is 'true' if a runtime identifier is specified."
+          ]
+        },
+        {
+          "name": "--use-current-runtime",
+          "alias": [
+            "--ucr"
+          ],
+          "usage": [
+            "--ucr, --use-current-runtime"
+          ],
+          "tip": [
+            "Use current runtime as the target runtime."
+          ]
+        },
+        {
+          "name": "--verbosity",
+          "alias": [
+            "-verbosity",
+            "-v"
+          ],
+          "usage": [
+            "-v, -verbosity, --verbosity <LEVEL>"
+          ],
+          "tip": [
+            "Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]."
+          ],
+          "next": [
+            {
+              "name": "detailed"
+            },
+            {
+              "name": "diagnostic"
+            },
+            {
+              "name": "minimal"
+            },
+            {
+              "name": "normal"
+            },
+            {
+              "name": "quiet"
+            }
+          ]
+        },
+        {
+          "name": "--version-suffix",
+          "usage": [
+            "--version-suffix <VERSION_SUFFIX>"
+          ],
+          "tip": [
+            "Set the value of the $(VersionSuffix) property to use when building the project."
+          ],
+          "next": []
+        }
       ]
     },
     {
       "name": "reference",
       "tip": [
-        ".NET commands for manipulate project reference"
+        "Add, remove, or list ProjectReferences for a .NET project."
+      ],
+      "option": [
+        {
+          "name": "--project",
+          "usage": [
+            "--project <PROJECT>"
+          ],
+          "tip": [
+            "The project file to operate on. If a file is not specified, the command will search the current directory for one."
+          ],
+          "next": []
+        }
       ],
       "next": [
         {
           "name": "add",
+          "usage": [
+            "add <PROJECT_PATH>"
+          ],
           "tip": [
-            "Adds a project reference."
+            "Add a project-to-project reference to the project."
+          ],
+          "option": [
+            {
+              "name": "--file",
+              "usage": [
+                "--file <FILE>"
+              ],
+              "tip": [
+                "The file-based app to operate on."
+              ],
+              "next": []
+            },
+            {
+              "name": "--framework",
+              "alias": [
+                "-f"
+              ],
+              "usage": [
+                "-f, --framework <FRAMEWORK>"
+              ],
+              "tip": [
+                "Add the reference only when targeting a specific framework."
+              ],
+              "next": [
+                {
+                  "name": "net10.0",
+                  "tip": [
+                    ".NET 10"
+                  ]
+                },
+                {
+                  "name": "net8.0",
+                  "tip": [
+                    ".NET 8"
+                  ]
+                },
+                {
+                  "name": "net9.0",
+                  "tip": [
+                    ".NET 9"
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+              ]
+            },
+            {
+              "name": "--project",
+              "usage": [
+                "--project <PROJECT>"
+              ],
+              "tip": [
+                "The project file to operate on. If a file is not specified, the command will search the current directory for one."
+              ],
+              "next": []
+            }
           ]
         },
         {
           "name": "list",
           "tip": [
-            "Lists project references."
+            "List all project-to-project references of the project."
+          ],
+          "option": [
+            {
+              "name": "--file",
+              "usage": [
+                "--file <FILE>"
+              ],
+              "tip": [
+                "The file-based app to operate on."
+              ],
+              "next": []
+            },
+            {
+              "name": "--project",
+              "usage": [
+                "--project <PROJECT>"
+              ],
+              "tip": [
+                "The project file to operate on. If a file is not specified, the command will search the current directory for one."
+              ],
+              "next": []
+            }
           ]
         },
         {
           "name": "remove",
+          "usage": [
+            "remove <PROJECT_PATH>"
+          ],
           "tip": [
-            "Removes a project reference."
+            "Remove a project-to-project reference from the project."
+          ],
+          "option": [
+            {
+              "name": "--file",
+              "usage": [
+                "--file <FILE>"
+              ],
+              "tip": [
+                "The file-based app to operate on."
+              ],
+              "next": []
+            },
+            {
+              "name": "--framework",
+              "alias": [
+                "-f"
+              ],
+              "usage": [
+                "-f, --framework <FRAMEWORK>"
+              ],
+              "tip": [
+                "Remove the reference only when targeting a specific framework."
+              ],
+              "next": [
+                {
+                  "name": "net10.0",
+                  "tip": [
+                    ".NET 10"
+                  ]
+                },
+                {
+                  "name": "net8.0",
+                  "tip": [
+                    ".NET 8"
+                  ]
+                },
+                {
+                  "name": "net9.0",
+                  "tip": [
+                    ".NET 9"
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "--project",
+              "usage": [
+                "--project <PROJECT>"
+              ],
+              "tip": [
+                "The project file to operate on. If a file is not specified, the command will search the current directory for one."
+              ],
+              "next": []
+            }
           ]
         }
       ]
@@ -320,83 +4877,3740 @@
     {
       "name": "restore",
       "tip": [
-        "Restores the dependencies for a given application."
-      ]
-    },
-    {
-      "name": "run",
-      "tip": [
-        "Runs the application from source."
-      ]
-    },
-    {
-      "name": "sdk",
-      "tip": [
-        ".NET command for SDK."
+        "Restore dependencies specified in a .NET project."
       ],
-      "next": [
+      "option": [
         {
-          "name": "check",
+          "name": "--arch",
+          "alias": [
+            "-a"
+          ],
+          "usage": [
+            "-a, --arch <ARCH>"
+          ],
           "tip": [
-            "Shows up-to-date status of installed SDK and Runtime versions."
+            "The target architecture."
+          ],
+          "next": [
+            {
+              "name": "arm",
+              "tip": [
+                "ARM32"
+              ]
+            },
+            {
+              "name": "arm64",
+              "tip": [
+                "ARM64"
+              ]
+            },
+            {
+              "name": "x64",
+              "tip": [
+                "64-bit x86"
+              ]
+            },
+            {
+              "name": "x86",
+              "tip": [
+                "32-bit x86"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--artifacts-path",
+          "usage": [
+            "--artifacts-path <ARTIFACTS_DIR>"
+          ],
+          "tip": [
+            "The artifacts path. All output from the project, including build, publish, and pack output, will go in subfolders under the specified path."
+          ],
+          "next": []
+        },
+        {
+          "name": "--configfile",
+          "usage": [
+            "--configfile <FILE>"
+          ],
+          "tip": [
+            "The NuGet configuration file to use."
+          ],
+          "next": []
+        },
+        {
+          "name": "--disable-build-servers",
+          "tip": [
+            "Force the command to ignore any persistent build servers."
+          ]
+        },
+        {
+          "name": "--disable-parallel",
+          "tip": [
+            "Prevent restoring multiple projects in parallel."
+          ]
+        },
+        {
+          "name": "--force",
+          "alias": [
+            "-f"
+          ],
+          "usage": [
+            "-f, --force"
+          ],
+          "tip": [
+            "Force all dependencies to be resolved even if the last restore was successful.",
+            "This is equivalent to deleting project.assets.json."
+          ]
+        },
+        {
+          "name": "--force-evaluate",
+          "tip": [
+            "Forces restore to reevaluate all dependencies even if a lock file already exists."
+          ]
+        },
+        {
+          "name": "--ignore-failed-sources",
+          "tip": [
+            "Treat package source failures as warnings."
+          ]
+        },
+        {
+          "name": "--interactive",
+          "tip": [
+            "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+          ]
+        },
+        {
+          "name": "--lock-file-path",
+          "usage": [
+            "--lock-file-path <LOCK_FILE_PATH>"
+          ],
+          "tip": [
+            "Output location where project lock file is written. By default, this is 'PROJECT_ROOT\\packages.lock.json'."
+          ],
+          "next": []
+        },
+        {
+          "name": "--locked-mode",
+          "tip": [
+            "Don't allow updating project lock file."
+          ]
+        },
+        {
+          "name": "--no-dependencies",
+          "tip": [
+            "Do not restore project-to-project references and only restore the specified project."
+          ]
+        },
+        {
+          "name": "--no-http-cache",
+          "tip": [
+            "Disable Http Caching for packages."
+          ]
+        },
+        {
+          "name": "--no-logo",
+          "alias": [
+            "-nologo"
+          ],
+          "usage": [
+            "-nologo, --no-logo"
+          ],
+          "tip": [
+            "Do not display the startup banner or the copyright message."
+          ]
+        },
+        {
+          "name": "--os",
+          "usage": [
+            "--os <OS>"
+          ],
+          "tip": [
+            "The target operating system."
+          ],
+          "next": [
+            {
+              "name": "linux",
+              "tip": [
+                "Linux"
+              ]
+            },
+            {
+              "name": "osx",
+              "tip": [
+                "macOS"
+              ]
+            },
+            {
+              "name": "win",
+              "tip": [
+                "Windows"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--packages",
+          "usage": [
+            "--packages <PACKAGES_DIR>"
+          ],
+          "tip": [
+            "The directory to restore packages to."
+          ],
+          "next": []
+        },
+        {
+          "name": "--runtime",
+          "alias": [
+            "-r"
+          ],
+          "usage": [
+            "-r, --runtime <RUNTIME_IDENTIFIER>"
+          ],
+          "tip": [
+            "The target runtime to restore packages for."
+          ],
+          "next": [
+            {
+              "name": "linux-x64",
+              "tip": [
+                "Linux x64"
+              ]
+            },
+            {
+              "name": "osx-arm64",
+              "tip": [
+                "macOS ARM64"
+              ]
+            },
+            {
+              "name": "win-x64",
+              "tip": [
+                "Windows x64"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--source",
+          "alias": [
+            "-s"
+          ],
+          "usage": [
+            "-s, --source <SOURCE>"
+          ],
+          "tip": [
+            "The NuGet package source to use for the restore."
+          ],
+          "repeat": 99,
+          "next": []
+        },
+        {
+          "name": "--use-current-runtime",
+          "alias": [
+            "--ucr"
+          ],
+          "usage": [
+            "--ucr, --use-current-runtime"
+          ],
+          "tip": [
+            "Use current runtime as the target runtime."
+          ]
+        },
+        {
+          "name": "--use-lock-file",
+          "tip": [
+            "Enables project lock file to be generated and used with restore."
+          ]
+        },
+        {
+          "name": "--verbosity",
+          "alias": [
+            "-v"
+          ],
+          "usage": [
+            "-v, --verbosity <LEVEL>"
+          ],
+          "tip": [
+            "Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]. [default: minimal]"
+          ],
+          "next": [
+            {
+              "name": "detailed"
+            },
+            {
+              "name": "diagnostic"
+            },
+            {
+              "name": "minimal"
+            },
+            {
+              "name": "normal"
+            },
+            {
+              "name": "quiet"
+            }
           ]
         }
       ]
     },
     {
-      "name": "sln",
+      "name": "run",
       "tip": [
-        "Options to add, remove, and list projects in a solution file."
+        "Build and run a .NET project output."
+      ],
+      "option": [
+        {
+          "name": "--arch",
+          "alias": [
+            "-a"
+          ],
+          "usage": [
+            "-a, --arch <ARCH>"
+          ],
+          "tip": [
+            "The target architecture."
+          ],
+          "next": [
+            {
+              "name": "arm",
+              "tip": [
+                "ARM32"
+              ]
+            },
+            {
+              "name": "arm64",
+              "tip": [
+                "ARM64"
+              ]
+            },
+            {
+              "name": "x64",
+              "tip": [
+                "64-bit x86"
+              ]
+            },
+            {
+              "name": "x86",
+              "tip": [
+                "32-bit x86"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--artifacts-path",
+          "usage": [
+            "--artifacts-path <ARTIFACTS_DIR>"
+          ],
+          "tip": [
+            "The artifacts path. All output from the project, including build, publish, and pack output, will go in subfolders under the specified path."
+          ],
+          "next": []
+        },
+        {
+          "name": "--configuration",
+          "alias": [
+            "-c"
+          ],
+          "usage": [
+            "-c, --configuration <CONFIGURATION>"
+          ],
+          "tip": [
+            "The configuration to run for. The default for most projects is 'Debug'."
+          ],
+          "next": [
+            {
+              "name": "Debug"
+            },
+            {
+              "name": "Release"
+            }
+          ]
+        },
+        {
+          "name": "--device",
+          "usage": [
+            "--device <DEVICE>"
+          ],
+          "tip": [
+            "The device identifier to use for running the application."
+          ],
+          "next": []
+        },
+        {
+          "name": "--disable-build-servers",
+          "tip": [
+            "Force the command to ignore any persistent build servers."
+          ]
+        },
+        {
+          "name": "--environment",
+          "alias": [
+            "-e"
+          ],
+          "usage": [
+            "-e, --environment <NAME=VALUE>"
+          ],
+          "tip": [
+            "Sets the value of an environment variable.",
+            "Creates the variable if it does not exist, overrides if it does.",
+            "This argument can be specified multiple times to provide multiple variables."
+          ],
+          "repeat": 99,
+          "next": []
+        },
+        {
+          "name": "--file",
+          "usage": [
+            "--file <FILE_PATH>"
+          ],
+          "tip": [
+            "The path to the file-based app to run (can be also passed as the first argument if there is no project in the current directory)."
+          ],
+          "next": []
+        },
+        {
+          "name": "--framework",
+          "alias": [
+            "-f"
+          ],
+          "usage": [
+            "-f, --framework <FRAMEWORK>"
+          ],
+          "tip": [
+            "The target framework to run for. The target framework must also be specified in the project file."
+          ],
+          "next": [
+            {
+              "name": "net10.0",
+              "tip": [
+                ".NET 10"
+              ]
+            },
+            {
+              "name": "net8.0",
+              "tip": [
+                ".NET 8"
+              ]
+            },
+            {
+              "name": "net9.0",
+              "tip": [
+                ".NET 9"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--interactive",
+          "tip": [
+            "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+          ]
+        },
+        {
+          "name": "--launch-profile",
+          "alias": [
+            "-lp"
+          ],
+          "usage": [
+            "-lp, --launch-profile <LAUNCH_PROFILE>"
+          ],
+          "tip": [
+            "The name of the launch profile (if any) to use when launching the application."
+          ],
+          "next": []
+        },
+        {
+          "name": "--list-devices",
+          "tip": [
+            "List available devices for running the application."
+          ]
+        },
+        {
+          "name": "--no-build",
+          "tip": [
+            "Do not build the project before running. Implies --no-restore."
+          ]
+        },
+        {
+          "name": "--no-cache",
+          "tip": [
+            "Skip up to date checks and always build the program before running."
+          ]
+        },
+        {
+          "name": "--no-launch-profile",
+          "tip": [
+            "Do not attempt to use launchSettings.json or [app].run.json to configure the application."
+          ]
+        },
+        {
+          "name": "--no-restore",
+          "tip": [
+            "Do not restore the project before building."
+          ]
+        },
+        {
+          "name": "--no-self-contained",
+          "tip": [
+            "Publish your application as a framework dependent application. A compatible .NET runtime must be installed on the target machine to run your application."
+          ]
+        },
+        {
+          "name": "--os",
+          "usage": [
+            "--os <OS>"
+          ],
+          "tip": [
+            "The target operating system."
+          ],
+          "next": [
+            {
+              "name": "linux",
+              "tip": [
+                "Linux"
+              ]
+            },
+            {
+              "name": "osx",
+              "tip": [
+                "macOS"
+              ]
+            },
+            {
+              "name": "win",
+              "tip": [
+                "Windows"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--project",
+          "usage": [
+            "--project <PROJECT_PATH>"
+          ],
+          "tip": [
+            "Defines the path of the project file to run. Use path to the project file, or path to the directory containing the project file. If not specified, it defaults to the current directory."
+          ],
+          "next": []
+        },
+        {
+          "name": "--runtime",
+          "alias": [
+            "-r"
+          ],
+          "usage": [
+            "-r, --runtime <RUNTIME_IDENTIFIER>"
+          ],
+          "tip": [
+            "The target runtime to run for."
+          ],
+          "next": [
+            {
+              "name": "linux-x64",
+              "tip": [
+                "Linux x64"
+              ]
+            },
+            {
+              "name": "osx-arm64",
+              "tip": [
+                "macOS ARM64"
+              ]
+            },
+            {
+              "name": "win-x64",
+              "tip": [
+                "Windows x64"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--self-contained",
+          "alias": [
+            "--sc"
+          ],
+          "usage": [
+            "--sc, --self-contained"
+          ],
+          "tip": [
+            "Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.",
+            "The default is 'false.' However, when targeting .NET 7 or lower, the default is 'true' if a runtime identifier is specified."
+          ]
+        },
+        {
+          "name": "--verbosity",
+          "alias": [
+            "-verbosity",
+            "-v"
+          ],
+          "usage": [
+            "-v, -verbosity, --verbosity <LEVEL>"
+          ],
+          "tip": [
+            "Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]."
+          ],
+          "next": [
+            {
+              "name": "detailed"
+            },
+            {
+              "name": "diagnostic"
+            },
+            {
+              "name": "minimal"
+            },
+            {
+              "name": "normal"
+            },
+            {
+              "name": "quiet"
+            }
+          ]
+        }
       ]
     },
     {
-      "name": "store",
+      "name": "sdk",
       "tip": [
-        "Stores assemblies in the runtime package store."
-      ]
-    },
-    {
-      "name": "test",
-      "tip": [
-        "Runs tests using a test runner."
-      ]
-    },
-    {
-      "name": "tool",
-      "tip": [
-        "Install or use tools that extend the .NET experience.",
-        "Tools are console applications that are installed from NuGet packages and are invoked from the command prompt.",
-        "You can write tools yourself or install tools written by third parties."
+        "Manage .NET SDK installation."
       ],
       "next": [
         {
-          "name": "install",
+          "name": "check",
           "tip": [
-            "Installs a tool on your machine."
+            "Displays the latest available SDK and runtime versions for the installed feature bands."
+          ]
+        }
+      ]
+    },
+    {
+      "name": "solution",
+      "alias": [
+        "sln"
+      ],
+      "usage": [
+        "sln|solution [<SLN_FILE>]"
+      ],
+      "tip": [
+        "Modify Visual Studio solution files."
+      ],
+      "next": [
+        {
+          "name": "add",
+          "usage": [
+            "add <PROJECT_PATH>"
+          ],
+          "tip": [
+            "Add one or more projects to a solution file."
+          ],
+          "option": [
+            {
+              "name": "--in-root",
+              "tip": [
+                "Place project in root of the solution, rather than creating a solution folder."
+              ]
+            },
+            {
+              "name": "--include-references",
+              "tip": [
+                "Recursively add projects' ReferencedProjects to solution."
+              ]
+            },
+            {
+              "name": "--solution-folder",
+              "alias": [
+                "-s"
+              ],
+              "usage": [
+                "-s, --solution-folder <SOLUTION_FOLDER>"
+              ],
+              "tip": [
+                "The destination solution folder path to add the projects to."
+              ],
+              "next": []
+            }
           ]
         },
         {
           "name": "list",
           "tip": [
-            "Lists all global, tool-path, or local tools currently installed on your machine."
+            "List all projects in a solution file."
+          ],
+          "option": [
+            {
+              "name": "--solution-folders",
+              "tip": [
+                "Display solution folder paths."
+              ]
+            }
+          ]
+        },
+        {
+          "name": "migrate",
+          "tip": [
+            "Generate a .slnx file from a .sln file."
+          ]
+        },
+        {
+          "name": "remove",
+          "usage": [
+            "remove <PROJECT_PATH>"
+          ],
+          "tip": [
+            "Remove one or more projects from a solution file."
+          ]
+        }
+      ]
+    },
+    {
+      "name": "store",
+      "tip": [
+        "Store the specified assemblies in the runtime package store."
+      ],
+      "option": [
+        {
+          "name": "--disable-build-servers",
+          "tip": [
+            "Force the command to ignore any persistent build servers."
+          ]
+        },
+        {
+          "name": "--framework",
+          "alias": [
+            "-f"
+          ],
+          "usage": [
+            "-f, --framework <FRAMEWORK>"
+          ],
+          "tip": [
+            "The target framework to store packages for. The target framework has to be specified in the project file."
+          ],
+          "next": [
+            {
+              "name": "net10.0",
+              "tip": [
+                ".NET 10"
+              ]
+            },
+            {
+              "name": "net8.0",
+              "tip": [
+                ".NET 8"
+              ]
+            },
+            {
+              "name": "net9.0",
+              "tip": [
+                ".NET 9"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--framework-version",
+          "usage": [
+            "--framework-version <FRAMEWORK_VERSION>"
+          ],
+          "tip": [
+            "The Microsoft.NETCore.App package version that will be used to run the assemblies."
+          ],
+          "next": []
+        },
+        {
+          "name": "--manifest",
+          "alias": [
+            "-m"
+          ],
+          "usage": [
+            "-m, --manifest <PROJECT_MANIFEST>"
+          ],
+          "tip": [
+            "The XML file that contains the list of packages to be stored."
+          ],
+          "repeat": 99,
+          "next": []
+        },
+        {
+          "name": "--no-logo",
+          "alias": [
+            "-nologo"
+          ],
+          "usage": [
+            "-nologo, --no-logo"
+          ],
+          "tip": [
+            "Do not display the startup banner or the copyright message."
+          ]
+        },
+        {
+          "name": "--output",
+          "alias": [
+            "-o"
+          ],
+          "usage": [
+            "-o, --output <OUTPUT_DIR>"
+          ],
+          "tip": [
+            "The output directory to store the given assemblies in."
+          ],
+          "next": []
+        },
+        {
+          "name": "--runtime",
+          "alias": [
+            "-r"
+          ],
+          "usage": [
+            "-r, --runtime <RUNTIME_IDENTIFIER>"
+          ],
+          "tip": [
+            "The target runtime to store packages for."
+          ],
+          "next": [
+            {
+              "name": "linux-x64",
+              "tip": [
+                "Linux x64"
+              ]
+            },
+            {
+              "name": "osx-arm64",
+              "tip": [
+                "macOS ARM64"
+              ]
+            },
+            {
+              "name": "win-x64",
+              "tip": [
+                "Windows x64"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--skip-optimization",
+          "tip": [
+            "Skip the optimization phase."
+          ]
+        },
+        {
+          "name": "--skip-symbols",
+          "tip": [
+            "Skip creating symbol files which can be used for profiling the optimized assemblies."
+          ]
+        },
+        {
+          "name": "--use-current-runtime",
+          "alias": [
+            "--ucr"
+          ],
+          "usage": [
+            "--ucr, --use-current-runtime"
+          ],
+          "tip": [
+            "Use current runtime as the target runtime."
+          ]
+        },
+        {
+          "name": "--verbosity",
+          "alias": [
+            "-verbosity",
+            "-v"
+          ],
+          "usage": [
+            "-v, -verbosity, --verbosity <LEVEL>"
+          ],
+          "tip": [
+            "Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]."
+          ],
+          "next": [
+            {
+              "name": "detailed"
+            },
+            {
+              "name": "diagnostic"
+            },
+            {
+              "name": "minimal"
+            },
+            {
+              "name": "normal"
+            },
+            {
+              "name": "quiet"
+            }
+          ]
+        },
+        {
+          "name": "--working-dir",
+          "alias": [
+            "-w"
+          ],
+          "usage": [
+            "-w, --working-dir <WORKING_DIR>"
+          ],
+          "tip": [
+            "The working directory used by the command to execute."
+          ],
+          "next": []
+        }
+      ]
+    },
+    {
+      "name": "test",
+      "tip": [
+        "Run unit tests using the test runner specified in a .NET project."
+      ],
+      "option": [
+        {
+          "name": "--arch",
+          "alias": [
+            "-a"
+          ],
+          "usage": [
+            "-a, --arch <ARCH>"
+          ],
+          "tip": [
+            "The target architecture."
+          ],
+          "next": [
+            {
+              "name": "arm",
+              "tip": [
+                "ARM32"
+              ]
+            },
+            {
+              "name": "arm64",
+              "tip": [
+                "ARM64"
+              ]
+            },
+            {
+              "name": "x64",
+              "tip": [
+                "64-bit x86"
+              ]
+            },
+            {
+              "name": "x86",
+              "tip": [
+                "32-bit x86"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--artifacts-path",
+          "usage": [
+            "--artifacts-path <ARTIFACTS_DIR>"
+          ],
+          "tip": [
+            "The artifacts path. All output from the project, including build, publish, and pack output, will go in subfolders under the specified path."
+          ],
+          "next": []
+        },
+        {
+          "name": "--blame",
+          "tip": [
+            "Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang."
+          ]
+        },
+        {
+          "name": "--blame-crash",
+          "tip": [
+            "Runs the tests in blame mode and collects a crash dump when the test host exits unexpectedly. Implies --blame."
+          ]
+        },
+        {
+          "name": "--blame-crash-collect-always",
+          "tip": [
+            "Enables collecting crash dump on expected as well as unexpected testhost exit."
+          ]
+        },
+        {
+          "name": "--blame-crash-dump-type",
+          "usage": [
+            "--blame-crash-dump-type <DUMP_TYPE>"
+          ],
+          "tip": [
+            "The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash."
+          ],
+          "next": [
+            {
+              "name": "full"
+            },
+            {
+              "name": "mini"
+            }
+          ]
+        },
+        {
+          "name": "--blame-hang",
+          "tip": [
+            "Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout."
+          ]
+        },
+        {
+          "name": "--blame-hang-dump-type",
+          "usage": [
+            "--blame-hang-dump-type <DUMP_TYPE>"
+          ],
+          "tip": [
+            "The type of crash dump to be collected. The supported values are full (default), mini, and none. Implies --blame-hang."
+          ],
+          "next": [
+            {
+              "name": "full"
+            },
+            {
+              "name": "mini"
+            },
+            {
+              "name": "none"
+            }
+          ]
+        },
+        {
+          "name": "--blame-hang-timeout",
+          "usage": [
+            "--blame-hang-timeout <TIMESPAN>"
+          ],
+          "tip": [
+            "Per-test timeout, after which hang dump is triggered and the testhost process is terminated. Default is 1h.",
+            "The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms."
+          ],
+          "next": [
+            {
+              "name": "10m",
+              "tip": [
+                "10 minutes"
+              ]
+            },
+            {
+              "name": "1h",
+              "tip": [
+                "1 hour"
+              ]
+            },
+            {
+              "name": "1m",
+              "tip": [
+                "1 minute"
+              ]
+            },
+            {
+              "name": "30m",
+              "tip": [
+                "30 minutes"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--collect",
+          "usage": [
+            "--collect <DATA_COLLECTOR_NAME>"
+          ],
+          "tip": [
+            "The friendly name of the data collector to use for the test run."
+          ],
+          "next": [
+            {
+              "name": "\"Code Coverage\"",
+              "tip": [
+                "Code coverage data collector"
+              ]
+            },
+            {
+              "name": "\"XPlat Code Coverage\"",
+              "tip": [
+                "Cross-platform code coverage data collector"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--configuration",
+          "alias": [
+            "-c"
+          ],
+          "usage": [
+            "-c, --configuration <CONFIGURATION>"
+          ],
+          "tip": [
+            "The configuration to use for running tests. The default for most projects is 'Debug'."
+          ],
+          "next": [
+            {
+              "name": "Debug"
+            },
+            {
+              "name": "Release"
+            }
+          ]
+        },
+        {
+          "name": "--diag",
+          "alias": [
+            "-d"
+          ],
+          "usage": [
+            "-d, --diag <LOG_FILE>"
+          ],
+          "tip": [
+            "Enable verbose logging to the specified file."
+          ],
+          "next": []
+        },
+        {
+          "name": "--disable-build-servers",
+          "tip": [
+            "Force the command to ignore any persistent build servers."
+          ]
+        },
+        {
+          "name": "--environment",
+          "alias": [
+            "-e"
+          ],
+          "usage": [
+            "-e, --environment <NAME=VALUE>"
+          ],
+          "tip": [
+            "Sets the value of an environment variable.",
+            "Creates the variable if it does not exist, overrides if it does.",
+            "This will force the tests to be run in an isolated process.",
+            "This argument can be specified multiple times to provide multiple variables."
+          ],
+          "repeat": 99,
+          "next": []
+        },
+        {
+          "name": "--filter",
+          "usage": [
+            "--filter <EXPRESSION>"
+          ],
+          "tip": [
+            "Run tests that match the given expression.",
+            "Examples: --filter \"FullyQualifiedName~Namespace.Class\"."
+          ],
+          "next": []
+        },
+        {
+          "name": "--framework",
+          "alias": [
+            "-f"
+          ],
+          "usage": [
+            "-f, --framework <FRAMEWORK>"
+          ],
+          "tip": [
+            "The target framework to run tests for. The target framework must also be specified in the project file."
+          ],
+          "next": [
+            {
+              "name": "net10.0",
+              "tip": [
+                ".NET 10"
+              ]
+            },
+            {
+              "name": "net8.0",
+              "tip": [
+                ".NET 8"
+              ]
+            },
+            {
+              "name": "net9.0",
+              "tip": [
+                ".NET 9"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--interactive",
+          "tip": [
+            "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+          ]
+        },
+        {
+          "name": "--list-tests",
+          "alias": [
+            "-t"
+          ],
+          "usage": [
+            "-t, --list-tests"
+          ],
+          "tip": [
+            "List the discovered tests instead of running the tests."
+          ]
+        },
+        {
+          "name": "--logger",
+          "alias": [
+            "-l"
+          ],
+          "usage": [
+            "-l, --logger <LOGGER>"
+          ],
+          "tip": [
+            "The logger to use for test results. Examples: trx;LogFileName=<TestResults.trx>."
+          ],
+          "repeat": 99,
+          "next": []
+        },
+        {
+          "name": "--no-build",
+          "tip": [
+            "Do not build the project before testing. Implies --no-restore."
+          ]
+        },
+        {
+          "name": "--no-logo",
+          "alias": [
+            "-nologo"
+          ],
+          "usage": [
+            "-nologo, --no-logo"
+          ],
+          "tip": [
+            "Run test(s), without displaying Microsoft Testplatform banner."
+          ]
+        },
+        {
+          "name": "--no-restore",
+          "tip": [
+            "Do not restore the project before building."
+          ]
+        },
+        {
+          "name": "--os",
+          "usage": [
+            "--os <OS>"
+          ],
+          "tip": [
+            "The target operating system."
+          ],
+          "next": [
+            {
+              "name": "linux",
+              "tip": [
+                "Linux"
+              ]
+            },
+            {
+              "name": "osx",
+              "tip": [
+                "macOS"
+              ]
+            },
+            {
+              "name": "win",
+              "tip": [
+                "Windows"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--output",
+          "alias": [
+            "-o"
+          ],
+          "usage": [
+            "-o, --output <OUTPUT_DIR>"
+          ],
+          "tip": [
+            "The output directory to place built artifacts in."
+          ],
+          "next": []
+        },
+        {
+          "name": "--results-directory",
+          "usage": [
+            "--results-directory <RESULTS_DIR>"
+          ],
+          "tip": [
+            "The directory where the test results will be placed. The specified directory will be created if it does not exist."
+          ],
+          "next": []
+        },
+        {
+          "name": "--runtime",
+          "alias": [
+            "-r"
+          ],
+          "usage": [
+            "-r, --runtime <RUNTIME_IDENTIFIER>"
+          ],
+          "tip": [
+            "The target runtime to test for."
+          ],
+          "next": [
+            {
+              "name": "linux-x64",
+              "tip": [
+                "Linux x64"
+              ]
+            },
+            {
+              "name": "osx-arm64",
+              "tip": [
+                "macOS ARM64"
+              ]
+            },
+            {
+              "name": "win-x64",
+              "tip": [
+                "Windows x64"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--settings",
+          "alias": [
+            "-s"
+          ],
+          "usage": [
+            "-s, --settings <SETTINGS_FILE>"
+          ],
+          "tip": [
+            "The settings file to use when running tests."
+          ],
+          "next": []
+        },
+        {
+          "name": "--test-adapter-path",
+          "usage": [
+            "--test-adapter-path <ADAPTER_PATH>"
+          ],
+          "tip": [
+            "The path to the custom adapters to use for the test run."
+          ],
+          "next": []
+        },
+        {
+          "name": "--verbosity",
+          "alias": [
+            "-v"
+          ],
+          "usage": [
+            "-v, --verbosity <LEVEL>"
+          ],
+          "tip": [
+            "Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]."
+          ],
+          "next": [
+            {
+              "name": "detailed"
+            },
+            {
+              "name": "diagnostic"
+            },
+            {
+              "name": "minimal"
+            },
+            {
+              "name": "normal"
+            },
+            {
+              "name": "quiet"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "tool",
+      "tip": [
+        "Install or manage tools that extend the .NET experience.",
+        "Tools are console applications that are installed from NuGet packages and are invoked from the command prompt.",
+        "You can write tools yourself or install tools written by third parties."
+      ],
+      "next": [
+        {
+          "name": "execute",
+          "alias": [
+            "exec"
+          ],
+          "usage": [
+            "exec|execute <PACKAGE_ID>"
+          ],
+          "tip": [
+            "Executes a tool from source without permanently installing it."
+          ],
+          "option": [
+            {
+              "name": "--add-source",
+              "usage": [
+                "--add-source <SOURCE>"
+              ],
+              "tip": [
+                "Add an additional NuGet package source to use during installation."
+              ],
+              "next": []
+            },
+            {
+              "name": "--allow-roll-forward",
+              "tip": [
+                "Allow a .NET tool to roll forward to newer versions of the .NET runtime if the runtime it targets isn't installed."
+              ]
+            },
+            {
+              "name": "--configfile",
+              "usage": [
+                "--configfile <FILE>"
+              ],
+              "tip": [
+                "The NuGet configuration file to use."
+              ],
+              "next": []
+            },
+            {
+              "name": "--disable-parallel",
+              "tip": [
+                "Prevent restoring multiple projects in parallel."
+              ]
+            },
+            {
+              "name": "--ignore-failed-sources",
+              "tip": [
+                "Treat package source failures as warnings."
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+              ]
+            },
+            {
+              "name": "--no-http-cache",
+              "tip": [
+                "Do not cache packages and http requests."
+              ]
+            },
+            {
+              "name": "--prerelease",
+              "tip": [
+                "Include pre-release packages."
+              ]
+            },
+            {
+              "name": "--source",
+              "usage": [
+                "--source <SOURCE>"
+              ],
+              "tip": [
+                "Replace all NuGet package sources to use during installation with these."
+              ],
+              "repeat": 99,
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]. [default: normal]"
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            },
+            {
+              "name": "--version",
+              "usage": [
+                "--version <VERSION>"
+              ],
+              "tip": [
+                "The version of the tool package to install."
+              ],
+              "next": []
+            }
+          ]
+        },
+        {
+          "name": "install",
+          "usage": [
+            "install <PACKAGE_ID>"
+          ],
+          "tip": [
+            "Install global or local tool. Local tools are added to manifest and restored."
+          ],
+          "option": [
+            {
+              "name": "--add-source",
+              "usage": [
+                "--add-source <SOURCE>"
+              ],
+              "tip": [
+                "Add an additional NuGet package source to use during installation."
+              ],
+              "next": []
+            },
+            {
+              "name": "--allow-downgrade",
+              "tip": [
+                "Allow package downgrade when installing a .NET tool package."
+              ]
+            },
+            {
+              "name": "--allow-roll-forward",
+              "tip": [
+                "Allow a .NET tool to roll forward to newer versions of the .NET runtime if the runtime it targets isn't installed."
+              ]
+            },
+            {
+              "name": "--arch",
+              "alias": [
+                "-a"
+              ],
+              "usage": [
+                "-a, --arch <ARCH>"
+              ],
+              "tip": [
+                "The target architecture."
+              ],
+              "next": [
+                {
+                  "name": "arm64",
+                  "tip": [
+                    "ARM64"
+                  ]
+                },
+                {
+                  "name": "x64",
+                  "tip": [
+                    "64-bit x86"
+                  ]
+                },
+                {
+                  "name": "x86",
+                  "tip": [
+                    "32-bit x86"
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "--configfile",
+              "usage": [
+                "--configfile <FILE>"
+              ],
+              "tip": [
+                "The NuGet configuration file to use."
+              ],
+              "next": []
+            },
+            {
+              "name": "--create-manifest-if-needed",
+              "tip": [
+                "Create a tool manifest if one isn't found during tool installation."
+              ]
+            },
+            {
+              "name": "--disable-parallel",
+              "tip": [
+                "Prevent restoring multiple projects in parallel."
+              ]
+            },
+            {
+              "name": "--framework",
+              "usage": [
+                "--framework <FRAMEWORK>"
+              ],
+              "tip": [
+                "The target framework to install the tool for."
+              ],
+              "next": [
+                {
+                  "name": "net10.0",
+                  "tip": [
+                    ".NET 10"
+                  ]
+                },
+                {
+                  "name": "net8.0",
+                  "tip": [
+                    ".NET 8"
+                  ]
+                },
+                {
+                  "name": "net9.0",
+                  "tip": [
+                    ".NET 9"
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "--global",
+              "alias": [
+                "-g"
+              ],
+              "usage": [
+                "-g, --global"
+              ],
+              "tip": [
+                "Install the tool for the current user."
+              ]
+            },
+            {
+              "name": "--ignore-failed-sources",
+              "tip": [
+                "Treat package source failures as warnings."
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+              ]
+            },
+            {
+              "name": "--local",
+              "tip": [
+                "Install the tool and add to the local tool manifest (default)."
+              ]
+            },
+            {
+              "name": "--no-http-cache",
+              "tip": [
+                "Do not cache packages and http requests."
+              ]
+            },
+            {
+              "name": "--prerelease",
+              "tip": [
+                "Include pre-release packages."
+              ]
+            },
+            {
+              "name": "--source",
+              "usage": [
+                "--source <SOURCE>"
+              ],
+              "tip": [
+                "Replace all NuGet package sources to use during installation with these."
+              ],
+              "repeat": 99,
+              "next": []
+            },
+            {
+              "name": "--tool-manifest",
+              "usage": [
+                "--tool-manifest <PATH>"
+              ],
+              "tip": [
+                "Path to the manifest file."
+              ],
+              "next": []
+            },
+            {
+              "name": "--tool-path",
+              "usage": [
+                "--tool-path <PATH>"
+              ],
+              "tip": [
+                "The directory where the tool will be installed. The directory will be created if it does not exist."
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]. [default: normal]"
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            },
+            {
+              "name": "--version",
+              "usage": [
+                "--version <VERSION>"
+              ],
+              "tip": [
+                "The version of the tool package to install."
+              ],
+              "next": []
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "usage": [
+            "list [<PACKAGE_ID>]"
+          ],
+          "tip": [
+            "List tools installed globally or locally."
+          ],
+          "option": [
+            {
+              "name": "--format",
+              "usage": [
+                "--format <JSON|TABLE>"
+              ],
+              "tip": [
+                "The output format for the list of tools. [default: table]"
+              ],
+              "next": [
+                {
+                  "name": "json"
+                },
+                {
+                  "name": "table"
+                }
+              ]
+            },
+            {
+              "name": "--global",
+              "alias": [
+                "-g"
+              ],
+              "usage": [
+                "-g, --global"
+              ],
+              "tip": [
+                "List tools installed for the current user."
+              ]
+            },
+            {
+              "name": "--local",
+              "tip": [
+                "List the tools installed in the local tool manifest."
+              ]
+            },
+            {
+              "name": "--tool-path",
+              "usage": [
+                "--tool-path <PATH>"
+              ],
+              "tip": [
+                "The directory containing the tools to list."
+              ],
+              "next": []
+            }
+          ]
+        },
+        {
+          "name": "restore",
+          "tip": [
+            "Restore tools defined in the local tool manifest."
+          ],
+          "option": [
+            {
+              "name": "--add-source",
+              "usage": [
+                "--add-source <SOURCE>"
+              ],
+              "tip": [
+                "Add an additional NuGet package source to use during installation."
+              ],
+              "next": []
+            },
+            {
+              "name": "--configfile",
+              "usage": [
+                "--configfile <FILE>"
+              ],
+              "tip": [
+                "The NuGet configuration file to use."
+              ],
+              "next": []
+            },
+            {
+              "name": "--disable-parallel",
+              "tip": [
+                "Prevent restoring multiple projects in parallel."
+              ]
+            },
+            {
+              "name": "--ignore-failed-sources",
+              "tip": [
+                "Treat package source failures as warnings."
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+              ]
+            },
+            {
+              "name": "--no-http-cache",
+              "tip": [
+                "Do not cache packages and http requests."
+              ]
+            },
+            {
+              "name": "--tool-manifest",
+              "usage": [
+                "--tool-manifest <PATH>"
+              ],
+              "tip": [
+                "Path to the manifest file."
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]. [default: normal]"
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "run",
+          "usage": [
+            "run <COMMAND_NAME>"
+          ],
+          "tip": [
+            "Run a local tool. Note that this command cannot be used to run a global tool."
+          ],
+          "option": [
+            {
+              "name": "--allow-roll-forward",
+              "tip": [
+                "Allow a .NET tool to roll forward to newer versions of the .NET runtime if the runtime it targets isn't installed."
+              ]
+            }
           ]
         },
         {
           "name": "search",
+          "usage": [
+            "search <SEARCH_TERM>"
+          ],
           "tip": [
-            "Searches NuGet.org for tools that have the specified search term in their name or metadata."
+            "Search dotnet tools in nuget.org."
+          ],
+          "option": [
+            {
+              "name": "--detail",
+              "tip": [
+                "Show detail result of the query."
+              ]
+            },
+            {
+              "name": "--prerelease",
+              "tip": [
+                "Include pre-release packages."
+              ]
+            },
+            {
+              "name": "--skip",
+              "usage": [
+                "--skip <SKIP>"
+              ],
+              "tip": [
+                "The number of results to skip, for pagination."
+              ],
+              "next": []
+            },
+            {
+              "name": "--take",
+              "usage": [
+                "--take <TAKE>"
+              ],
+              "tip": [
+                "The number of results to return, for pagination."
+              ],
+              "next": []
+            }
           ]
         },
         {
           "name": "uninstall",
+          "usage": [
+            "uninstall <PACKAGE_ID>"
+          ],
           "tip": [
-            "Uninstalls a tool from your machine."
+            "Uninstall a global tool or local tool."
+          ],
+          "option": [
+            {
+              "name": "--global",
+              "alias": [
+                "-g"
+              ],
+              "usage": [
+                "-g, --global"
+              ],
+              "tip": [
+                "Uninstall the tool from the current user's tools directory."
+              ]
+            },
+            {
+              "name": "--local",
+              "tip": [
+                "Uninstall the tool and remove it from the local tool manifest."
+              ]
+            },
+            {
+              "name": "--tool-manifest",
+              "usage": [
+                "--tool-manifest <PATH>"
+              ],
+              "tip": [
+                "Path to the manifest file."
+              ],
+              "next": []
+            },
+            {
+              "name": "--tool-path",
+              "usage": [
+                "--tool-path <PATH>"
+              ],
+              "tip": [
+                "The directory containing the tool to uninstall."
+              ],
+              "next": []
+            }
           ]
         },
         {
           "name": "update",
+          "usage": [
+            "update [<PACKAGE_ID>]"
+          ],
           "tip": [
-            "Updates a tool that is installed on your machine."
+            "Update a global or local tool."
+          ],
+          "option": [
+            {
+              "name": "--add-source",
+              "usage": [
+                "--add-source <SOURCE>"
+              ],
+              "tip": [
+                "Add an additional NuGet package source to use during installation."
+              ],
+              "next": []
+            },
+            {
+              "name": "--all",
+              "tip": [
+                "Update all tools."
+              ]
+            },
+            {
+              "name": "--allow-downgrade",
+              "tip": [
+                "Allow package downgrade when installing a .NET tool package."
+              ]
+            },
+            {
+              "name": "--configfile",
+              "usage": [
+                "--configfile <FILE>"
+              ],
+              "tip": [
+                "The NuGet configuration file to use."
+              ],
+              "next": []
+            },
+            {
+              "name": "--disable-parallel",
+              "tip": [
+                "Prevent restoring multiple projects in parallel."
+              ]
+            },
+            {
+              "name": "--framework",
+              "usage": [
+                "--framework <FRAMEWORK>"
+              ],
+              "tip": [
+                "The target framework to install the tool for."
+              ],
+              "next": [
+                {
+                  "name": "net10.0",
+                  "tip": [
+                    ".NET 10"
+                  ]
+                },
+                {
+                  "name": "net8.0",
+                  "tip": [
+                    ".NET 8"
+                  ]
+                },
+                {
+                  "name": "net9.0",
+                  "tip": [
+                    ".NET 9"
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "--global",
+              "alias": [
+                "-g"
+              ],
+              "usage": [
+                "-g, --global"
+              ],
+              "tip": [
+                "Install the tool for the current user."
+              ]
+            },
+            {
+              "name": "--ignore-failed-sources",
+              "tip": [
+                "Treat package source failures as warnings."
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+              ]
+            },
+            {
+              "name": "--local",
+              "tip": [
+                "Install the tool and add to the local tool manifest (default)."
+              ]
+            },
+            {
+              "name": "--no-http-cache",
+              "tip": [
+                "Do not cache packages and http requests."
+              ]
+            },
+            {
+              "name": "--prerelease",
+              "tip": [
+                "Include pre-release packages."
+              ]
+            },
+            {
+              "name": "--source",
+              "usage": [
+                "--source <SOURCE>"
+              ],
+              "tip": [
+                "Replace all NuGet package sources to use during installation with these."
+              ],
+              "repeat": 99,
+              "next": []
+            },
+            {
+              "name": "--tool-manifest",
+              "usage": [
+                "--tool-manifest <PATH>"
+              ],
+              "tip": [
+                "Path to the manifest file."
+              ],
+              "next": []
+            },
+            {
+              "name": "--tool-path",
+              "usage": [
+                "--tool-path <PATH>"
+              ],
+              "tip": [
+                "The directory where the tool will be installed. The directory will be created if it does not exist."
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]. [default: normal]"
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            },
+            {
+              "name": "--version",
+              "usage": [
+                "--version <VERSION>"
+              ],
+              "tip": [
+                "The version of the tool package to install."
+              ],
+              "next": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "user-jwts",
+      "tip": [
+        "Manage JSON Web Tokens in development."
+      ],
+      "option": [
+        {
+          "name": "--output",
+          "alias": [
+            "-o"
+          ],
+          "usage": [
+            "-o, --output <FORMAT>"
+          ],
+          "tip": [
+            "The format to use for displaying output from the command. Can be one of 'default', 'token', or 'json'."
+          ],
+          "next": [
+            {
+              "name": "default"
+            },
+            {
+              "name": "json"
+            },
+            {
+              "name": "token"
+            }
+          ]
+        },
+        {
+          "name": "--project",
+          "alias": [
+            "-p"
+          ],
+          "usage": [
+            "-p, --project <PROJECT>"
+          ],
+          "tip": [
+            "The path of the project to operate on. Defaults to the project in the current directory."
+          ],
+          "next": []
+        }
+      ],
+      "next": [
+        {
+          "name": "clear",
+          "tip": [
+            "Remove all issued JWTs for a project."
+          ],
+          "option": [
+            {
+              "name": "--appsettings-file",
+              "usage": [
+                "--appsettings-file <FILE>"
+              ],
+              "tip": [
+                "The appSettings configuration file to add the test scheme to."
+              ],
+              "next": []
+            },
+            {
+              "name": "--force",
+              "tip": [
+                "Don't prompt for confirmation before deleting JWTs."
+              ]
+            },
+            {
+              "name": "--output",
+              "alias": [
+                "-o"
+              ],
+              "usage": [
+                "-o, --output <FORMAT>"
+              ],
+              "tip": [
+                "The format to use for displaying output from the command. Can be one of 'default', 'token', or 'json'."
+              ],
+              "next": [
+                {
+                  "name": "default"
+                },
+                {
+                  "name": "json"
+                },
+                {
+                  "name": "token"
+                }
+              ]
+            },
+            {
+              "name": "--project",
+              "alias": [
+                "-p"
+              ],
+              "usage": [
+                "-p, --project <PROJECT>"
+              ],
+              "tip": [
+                "The path of the project to operate on. Defaults to the project in the current directory."
+              ],
+              "next": []
+            }
+          ]
+        },
+        {
+          "name": "create",
+          "tip": [
+            "Issue a new JSON Web Token."
+          ],
+          "option": [
+            {
+              "name": "--appsettings-file",
+              "usage": [
+                "--appsettings-file <FILE>"
+              ],
+              "tip": [
+                "The appSettings configuration file to add the test scheme to."
+              ],
+              "next": []
+            },
+            {
+              "name": "--audience",
+              "usage": [
+                "--audience <AUDIENCE>"
+              ],
+              "tip": [
+                "The audiences to create the JWT for. Defaults to the URLs configured in the project's launchSettings.json."
+              ],
+              "next": []
+            },
+            {
+              "name": "--claim",
+              "usage": [
+                "--claim <NAME=VALUE>"
+              ],
+              "tip": [
+                "Claims to add to the JWT. Specify once for each claim in the format \"name=value\"."
+              ],
+              "repeat": 99,
+              "next": []
+            },
+            {
+              "name": "--expires-on",
+              "usage": [
+                "--expires-on <DATE_TIME>"
+              ],
+              "tip": [
+                "The UTC date & time the JWT should expire in the format 'yyyy-MM-dd [[[[HH:mm]]:ss]]'. Do not use this option in conjunction with the --valid-for option."
+              ],
+              "next": []
+            },
+            {
+              "name": "--issuer",
+              "usage": [
+                "--issuer <ISSUER>"
+              ],
+              "tip": [
+                "The issuer of the JWT. Defaults to 'dotnet-user-jwts'."
+              ],
+              "next": []
+            },
+            {
+              "name": "--name",
+              "alias": [
+                "-n"
+              ],
+              "usage": [
+                "-n, --name <NAME>"
+              ],
+              "tip": [
+                "The name of the user to create the JWT for. Defaults to the current environment user."
+              ],
+              "next": []
+            },
+            {
+              "name": "--not-before",
+              "usage": [
+                "--not-before <DATE_TIME>"
+              ],
+              "tip": [
+                "The UTC date & time the JWT should not be valid before in the format 'yyyy-MM-dd [[HH:mm[[:ss]]]]'."
+              ],
+              "next": []
+            },
+            {
+              "name": "--output",
+              "alias": [
+                "-o"
+              ],
+              "usage": [
+                "-o, --output <FORMAT>"
+              ],
+              "tip": [
+                "The format to use for displaying output from the command. Can be one of 'default', 'token', or 'json'."
+              ],
+              "next": [
+                {
+                  "name": "default"
+                },
+                {
+                  "name": "json"
+                },
+                {
+                  "name": "token"
+                }
+              ]
+            },
+            {
+              "name": "--project",
+              "alias": [
+                "-p"
+              ],
+              "usage": [
+                "-p, --project <PROJECT>"
+              ],
+              "tip": [
+                "The path of the project to operate on. Defaults to the project in the current directory."
+              ],
+              "next": []
+            },
+            {
+              "name": "--role",
+              "usage": [
+                "--role <ROLE>"
+              ],
+              "tip": [
+                "A role claim to add to the JWT. Specify once for each role."
+              ],
+              "repeat": 99,
+              "next": []
+            },
+            {
+              "name": "--scheme",
+              "usage": [
+                "--scheme <SCHEME>"
+              ],
+              "tip": [
+                "The scheme name to use for the generated token. Defaults to 'Bearer'."
+              ],
+              "next": [
+                {
+                  "name": "Bearer"
+                }
+              ]
+            },
+            {
+              "name": "--scope",
+              "usage": [
+                "--scope <SCOPE>"
+              ],
+              "tip": [
+                "A scope claim to add to the JWT. Specify once for each scope."
+              ],
+              "repeat": 99,
+              "next": []
+            },
+            {
+              "name": "--valid-for",
+              "usage": [
+                "--valid-for <PERIOD>"
+              ],
+              "tip": [
+                "The period the JWT should expire after. Specify using a number followed by a duration type like 'd' for days, 'h' for hours, e.g. '365d'. Do not use this option in conjunction with the --expires-on option."
+              ],
+              "next": [
+                {
+                  "name": "1h",
+                  "tip": [
+                    "1 hour"
+                  ]
+                },
+                {
+                  "name": "24h",
+                  "tip": [
+                    "24 hours"
+                  ]
+                },
+                {
+                  "name": "30d",
+                  "tip": [
+                    "30 days"
+                  ]
+                },
+                {
+                  "name": "365d",
+                  "tip": [
+                    "365 days"
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "key",
+          "tip": [
+            "Display or reset the signing key used to issue JWTs."
+          ],
+          "option": [
+            {
+              "name": "--force",
+              "tip": [
+                "Don't prompt for confirmation before resetting the signing key."
+              ]
+            },
+            {
+              "name": "--issuer",
+              "usage": [
+                "--issuer <ISSUER>"
+              ],
+              "tip": [
+                "The issuer associated with the signing key to be reset or displayed. Defaults to 'dotnet-user-jwts'."
+              ],
+              "next": []
+            },
+            {
+              "name": "--output",
+              "alias": [
+                "-o"
+              ],
+              "usage": [
+                "-o, --output <FORMAT>"
+              ],
+              "tip": [
+                "The format to use for displaying output from the command. Can be one of 'default', 'token', or 'json'."
+              ],
+              "next": [
+                {
+                  "name": "default"
+                },
+                {
+                  "name": "json"
+                },
+                {
+                  "name": "token"
+                }
+              ]
+            },
+            {
+              "name": "--project",
+              "alias": [
+                "-p"
+              ],
+              "usage": [
+                "-p, --project <PROJECT>"
+              ],
+              "tip": [
+                "The path of the project to operate on. Defaults to the project in the current directory."
+              ],
+              "next": []
+            },
+            {
+              "name": "--reset",
+              "tip": [
+                "Reset the signing key. This will invalidate all previously issued JWTs for this project."
+              ]
+            },
+            {
+              "name": "--scheme",
+              "usage": [
+                "--scheme <SCHEME>"
+              ],
+              "tip": [
+                "The scheme name associated with the signing key to be reset or displayed. Defaults to 'Bearer'."
+              ],
+              "next": []
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "tip": [
+            "Lists the JWTs issued for the project."
+          ],
+          "option": [
+            {
+              "name": "--output",
+              "alias": [
+                "-o"
+              ],
+              "usage": [
+                "-o, --output <FORMAT>"
+              ],
+              "tip": [
+                "The format to use for displaying output from the command. Can be one of 'default', 'token', or 'json'."
+              ],
+              "next": [
+                {
+                  "name": "default"
+                },
+                {
+                  "name": "json"
+                },
+                {
+                  "name": "token"
+                }
+              ]
+            },
+            {
+              "name": "--project",
+              "alias": [
+                "-p"
+              ],
+              "usage": [
+                "-p, --project <PROJECT>"
+              ],
+              "tip": [
+                "The path of the project to operate on. Defaults to the project in the current directory."
+              ],
+              "next": []
+            },
+            {
+              "name": "--show-tokens",
+              "tip": [
+                "Indicates whether JWT base64 strings should be shown."
+              ]
+            }
+          ]
+        },
+        {
+          "name": "print",
+          "usage": [
+            "print [<ID>]"
+          ],
+          "tip": [
+            "Print the details of a given JWT."
+          ],
+          "option": [
+            {
+              "name": "--output",
+              "alias": [
+                "-o"
+              ],
+              "usage": [
+                "-o, --output <FORMAT>"
+              ],
+              "tip": [
+                "The format to use for displaying output from the command. Can be one of 'default', 'token', or 'json'."
+              ],
+              "next": [
+                {
+                  "name": "default"
+                },
+                {
+                  "name": "json"
+                },
+                {
+                  "name": "token"
+                }
+              ]
+            },
+            {
+              "name": "--project",
+              "alias": [
+                "-p"
+              ],
+              "usage": [
+                "-p, --project <PROJECT>"
+              ],
+              "tip": [
+                "The path of the project to operate on. Defaults to the project in the current directory."
+              ],
+              "next": []
+            },
+            {
+              "name": "--show-all",
+              "tip": [
+                "Whether to show all details associated with the JWT."
+              ]
+            }
+          ]
+        },
+        {
+          "name": "remove",
+          "usage": [
+            "remove [<ID>]"
+          ],
+          "tip": [
+            "Remove a given JWT."
+          ],
+          "option": [
+            {
+              "name": "--appsettings-file",
+              "usage": [
+                "--appsettings-file <FILE>"
+              ],
+              "tip": [
+                "The appSettings configuration file to add the test scheme to."
+              ],
+              "next": []
+            },
+            {
+              "name": "--output",
+              "alias": [
+                "-o"
+              ],
+              "usage": [
+                "-o, --output <FORMAT>"
+              ],
+              "tip": [
+                "The format to use for displaying output from the command. Can be one of 'default', 'token', or 'json'."
+              ],
+              "next": [
+                {
+                  "name": "default"
+                },
+                {
+                  "name": "json"
+                },
+                {
+                  "name": "token"
+                }
+              ]
+            },
+            {
+              "name": "--project",
+              "alias": [
+                "-p"
+              ],
+              "usage": [
+                "-p, --project <PROJECT>"
+              ],
+              "tip": [
+                "The path of the project to operate on. Defaults to the project in the current directory."
+              ],
+              "next": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "user-secrets",
+      "tip": [
+        "Manage development user secrets."
+      ],
+      "option": [
+        {
+          "name": "--configuration",
+          "alias": [
+            "-c"
+          ],
+          "usage": [
+            "-c, --configuration <CONFIGURATION>"
+          ],
+          "tip": [
+            "The project configuration to use. Defaults to 'Debug'."
+          ],
+          "next": [
+            {
+              "name": "Debug"
+            },
+            {
+              "name": "Release"
+            }
+          ]
+        },
+        {
+          "name": "--file",
+          "alias": [
+            "-f"
+          ],
+          "usage": [
+            "-f, --file <FILE>"
+          ],
+          "tip": [
+            "Path to file-based app."
+          ],
+          "next": []
+        },
+        {
+          "name": "--id",
+          "usage": [
+            "--id <USER_SECRET_ID>"
+          ],
+          "tip": [
+            "The user secret ID to use."
+          ],
+          "next": []
+        },
+        {
+          "name": "--project",
+          "alias": [
+            "-p"
+          ],
+          "usage": [
+            "-p, --project <PROJECT>"
+          ],
+          "tip": [
+            "Path to project. Defaults to searching the current directory."
+          ],
+          "next": []
+        },
+        {
+          "name": "--verbose",
+          "alias": [
+            "-v"
+          ],
+          "usage": [
+            "-v, --verbose"
+          ],
+          "tip": [
+            "Show verbose output."
+          ]
+        },
+        {
+          "name": "--version",
+          "tip": [
+            "Show version information."
+          ]
+        }
+      ],
+      "next": [
+        {
+          "name": "clear",
+          "tip": [
+            "Deletes all the application secrets."
+          ],
+          "option": [
+            {
+              "name": "--configuration",
+              "alias": [
+                "-c"
+              ],
+              "usage": [
+                "-c, --configuration <CONFIGURATION>"
+              ],
+              "tip": [
+                "The project configuration to use. Defaults to 'Debug'."
+              ],
+              "next": [
+                {
+                  "name": "Debug"
+                },
+                {
+                  "name": "Release"
+                }
+              ]
+            },
+            {
+              "name": "--file",
+              "alias": [
+                "-f"
+              ],
+              "usage": [
+                "-f, --file <FILE>"
+              ],
+              "tip": [
+                "Path to file-based app."
+              ],
+              "next": []
+            },
+            {
+              "name": "--id",
+              "usage": [
+                "--id <USER_SECRET_ID>"
+              ],
+              "tip": [
+                "The user secret ID to use."
+              ],
+              "next": []
+            },
+            {
+              "name": "--project",
+              "alias": [
+                "-p"
+              ],
+              "usage": [
+                "-p, --project <PROJECT>"
+              ],
+              "tip": [
+                "Path to project. Defaults to searching the current directory."
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbose",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbose"
+              ],
+              "tip": [
+                "Show verbose output."
+              ]
+            }
+          ]
+        },
+        {
+          "name": "init",
+          "tip": [
+            "Set a user secrets ID to enable secret storage."
+          ],
+          "option": [
+            {
+              "name": "--configuration",
+              "alias": [
+                "-c"
+              ],
+              "usage": [
+                "-c, --configuration <CONFIGURATION>"
+              ],
+              "tip": [
+                "The project configuration to use. Defaults to 'Debug'."
+              ],
+              "next": [
+                {
+                  "name": "Debug"
+                },
+                {
+                  "name": "Release"
+                }
+              ]
+            },
+            {
+              "name": "--file",
+              "alias": [
+                "-f"
+              ],
+              "usage": [
+                "-f, --file <FILE>"
+              ],
+              "tip": [
+                "Path to file-based app."
+              ],
+              "next": []
+            },
+            {
+              "name": "--id",
+              "usage": [
+                "--id <USER_SECRET_ID>"
+              ],
+              "tip": [
+                "The user secret ID to use."
+              ],
+              "next": []
+            },
+            {
+              "name": "--project",
+              "alias": [
+                "-p"
+              ],
+              "usage": [
+                "-p, --project <PROJECT>"
+              ],
+              "tip": [
+                "Path to project. Defaults to searching the current directory."
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbose",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbose"
+              ],
+              "tip": [
+                "Show verbose output."
+              ]
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "tip": [
+            "Lists all the application secrets."
+          ],
+          "option": [
+            {
+              "name": "--configuration",
+              "alias": [
+                "-c"
+              ],
+              "usage": [
+                "-c, --configuration <CONFIGURATION>"
+              ],
+              "tip": [
+                "The project configuration to use. Defaults to 'Debug'."
+              ],
+              "next": [
+                {
+                  "name": "Debug"
+                },
+                {
+                  "name": "Release"
+                }
+              ]
+            },
+            {
+              "name": "--file",
+              "alias": [
+                "-f"
+              ],
+              "usage": [
+                "-f, --file <FILE>"
+              ],
+              "tip": [
+                "Path to file-based app."
+              ],
+              "next": []
+            },
+            {
+              "name": "--id",
+              "usage": [
+                "--id <USER_SECRET_ID>"
+              ],
+              "tip": [
+                "The user secret ID to use."
+              ],
+              "next": []
+            },
+            {
+              "name": "--json",
+              "tip": [
+                "Use json output. JSON is wrapped by '//BEGIN' and '//END'."
+              ]
+            },
+            {
+              "name": "--project",
+              "alias": [
+                "-p"
+              ],
+              "usage": [
+                "-p, --project <PROJECT>"
+              ],
+              "tip": [
+                "Path to project. Defaults to searching the current directory."
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbose",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbose"
+              ],
+              "tip": [
+                "Show verbose output."
+              ]
+            }
+          ]
+        },
+        {
+          "name": "remove",
+          "usage": [
+            "remove [<NAME>]"
+          ],
+          "tip": [
+            "Removes the specified user secret."
+          ],
+          "option": [
+            {
+              "name": "--configuration",
+              "alias": [
+                "-c"
+              ],
+              "usage": [
+                "-c, --configuration <CONFIGURATION>"
+              ],
+              "tip": [
+                "The project configuration to use. Defaults to 'Debug'."
+              ],
+              "next": [
+                {
+                  "name": "Debug"
+                },
+                {
+                  "name": "Release"
+                }
+              ]
+            },
+            {
+              "name": "--file",
+              "alias": [
+                "-f"
+              ],
+              "usage": [
+                "-f, --file <FILE>"
+              ],
+              "tip": [
+                "Path to file-based app."
+              ],
+              "next": []
+            },
+            {
+              "name": "--id",
+              "usage": [
+                "--id <USER_SECRET_ID>"
+              ],
+              "tip": [
+                "The user secret ID to use."
+              ],
+              "next": []
+            },
+            {
+              "name": "--project",
+              "alias": [
+                "-p"
+              ],
+              "usage": [
+                "-p, --project <PROJECT>"
+              ],
+              "tip": [
+                "Path to project. Defaults to searching the current directory."
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbose",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbose"
+              ],
+              "tip": [
+                "Show verbose output."
+              ]
+            }
+          ]
+        },
+        {
+          "name": "set",
+          "usage": [
+            "set <NAME> <VALUE>"
+          ],
+          "tip": [
+            "Sets the user secret to the specified value."
+          ],
+          "option": [
+            {
+              "name": "--configuration",
+              "alias": [
+                "-c"
+              ],
+              "usage": [
+                "-c, --configuration <CONFIGURATION>"
+              ],
+              "tip": [
+                "The project configuration to use. Defaults to 'Debug'."
+              ],
+              "next": [
+                {
+                  "name": "Debug"
+                },
+                {
+                  "name": "Release"
+                }
+              ]
+            },
+            {
+              "name": "--file",
+              "alias": [
+                "-f"
+              ],
+              "usage": [
+                "-f, --file <FILE>"
+              ],
+              "tip": [
+                "Path to file-based app."
+              ],
+              "next": []
+            },
+            {
+              "name": "--id",
+              "usage": [
+                "--id <USER_SECRET_ID>"
+              ],
+              "tip": [
+                "The user secret ID to use."
+              ],
+              "next": []
+            },
+            {
+              "name": "--project",
+              "alias": [
+                "-p"
+              ],
+              "usage": [
+                "-p, --project <PROJECT>"
+              ],
+              "tip": [
+                "Path to project. Defaults to searching the current directory."
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbose",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbose"
+              ],
+              "tip": [
+                "Show verbose output."
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "vstest",
+      "tip": [
+        "Run Microsoft Test Engine (VSTest) commands."
+      ],
+      "option": [
+        {
+          "name": "--Blame",
+          "usage": [
+            "--Blame [COLLECTDUMP]"
+          ],
+          "tip": [
+            "Runs the test in blame mode. This option is helpful in isolating the problematic test causing test host crash."
+          ],
+          "next": [
+            {
+              "name": "CollectDump",
+              "tip": [
+                "Collect a process dump for the test host"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--Collect",
+          "usage": [
+            "--Collect <DATA_COLLECTOR_NAME>"
+          ],
+          "tip": [
+            "Enables data collector for the test run."
+          ],
+          "next": [
+            {
+              "name": "\"Code Coverage\"",
+              "tip": [
+                "Code coverage data collector"
+              ]
+            },
+            {
+              "name": "\"XPlat Code Coverage\"",
+              "tip": [
+                "Cross-platform code coverage data collector"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--Diag",
+          "usage": [
+            "--Diag <LOG_FILE>"
+          ],
+          "tip": [
+            "Enable logs for test platform. Logs are written to the provided file."
+          ],
+          "next": []
+        },
+        {
+          "name": "--Environment",
+          "alias": [
+            "-e"
+          ],
+          "usage": [
+            "-e, --Environment <NAME=VALUE>"
+          ],
+          "tip": [
+            "Sets the value of an environment variable. Creates the variable if it does not exist, overrides if it does.",
+            "This argument can be specified multiple times to provide multiple variables."
+          ],
+          "repeat": 99,
+          "next": []
+        },
+        {
+          "name": "--Framework",
+          "usage": [
+            "--Framework <FRAMEWORK_VERSION>"
+          ],
+          "tip": [
+            "Target .NET Framework version to be used for test execution."
+          ],
+          "next": [
+            {
+              "name": ".NETCoreApp,Version=v10.0",
+              "tip": [
+                ".NET Core 10.0"
+              ]
+            },
+            {
+              "name": ".NETCoreApp,Version=v8.0",
+              "tip": [
+                ".NET Core 8.0"
+              ]
+            },
+            {
+              "name": ".NETFramework,Version=v4.5.1",
+              "tip": [
+                ".NET Framework 4.5.1"
+              ]
+            },
+            {
+              "name": ".NETFramework,Version=v4.8",
+              "tip": [
+                ".NET Framework 4.8"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--InIsolation",
+          "tip": [
+            "Runs the tests in an isolated process. This makes vstest.console.exe process less likely to be stopped on an error in the tests."
+          ]
+        },
+        {
+          "name": "--ListTests",
+          "alias": [
+            "-lt"
+          ],
+          "usage": [
+            "-lt, --ListTests <FILE_NAME>"
+          ],
+          "tip": [
+            "Lists all discovered tests from the given test container."
+          ],
+          "next": []
+        },
+        {
+          "name": "--logger",
+          "usage": [
+            "--logger <LOGGER_URI|FRIENDLYNAME>"
+          ],
+          "tip": [
+            "Specify a logger for test results. For example, to log results into a Visual Studio Test Results File (TRX) use --logger trx."
+          ],
+          "next": [
+            {
+              "name": "console",
+              "tip": [
+                "Console logger"
+              ]
+            },
+            {
+              "name": "trx",
+              "tip": [
+                "TRX file logger"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--Parallel",
+          "tip": [
+            "Specifies that the tests be executed in parallel. By default up to all available cores on the machine may be used."
+          ]
+        },
+        {
+          "name": "--Platform",
+          "usage": [
+            "--Platform <PLATFORM_TYPE>"
+          ],
+          "tip": [
+            "Target platform architecture to be used for test execution. Valid values are x86, x64 and ARM."
+          ],
+          "next": [
+            {
+              "name": "ARM"
+            },
+            {
+              "name": "x64"
+            },
+            {
+              "name": "x86"
+            }
+          ]
+        },
+        {
+          "name": "--ResultsDirectory",
+          "usage": [
+            "--ResultsDirectory <PATH>"
+          ],
+          "tip": [
+            "Test results directory will be created in specified path if not exists."
+          ],
+          "next": []
+        },
+        {
+          "name": "--Settings",
+          "usage": [
+            "--Settings <SETTINGS_FILE>"
+          ],
+          "tip": [
+            "Settings to use when running tests."
+          ],
+          "next": []
+        },
+        {
+          "name": "--TestAdapterLoadingStrategy",
+          "usage": [
+            "--TestAdapterLoadingStrategy <STRATEGY>"
+          ],
+          "tip": [
+            "This affects adapter loading behavior. Currently supported behaviors: Explicit, Default, DefaultRuntimeProviders, ExtensionsDirectory, NextToSource, and Recursive."
+          ],
+          "next": [
+            {
+              "name": "Default"
+            },
+            {
+              "name": "DefaultRuntimeProviders"
+            },
+            {
+              "name": "Explicit"
+            },
+            {
+              "name": "ExtensionsDirectory"
+            },
+            {
+              "name": "NextToSource"
+            },
+            {
+              "name": "Recursive"
+            }
+          ]
+        },
+        {
+          "name": "--TestAdapterPath",
+          "usage": [
+            "--TestAdapterPath <PATH>"
+          ],
+          "tip": [
+            "This makes vstest.console.exe process use custom test adapters from a given path (if any) in the test run."
+          ],
+          "next": []
+        },
+        {
+          "name": "--TestCaseFilter",
+          "usage": [
+            "--TestCaseFilter <EXPRESSION>"
+          ],
+          "tip": [
+            "Run tests that match the given expression. <Expression> is of the format <property>Operator<value>[|&<Expression>]."
+          ],
+          "next": []
+        },
+        {
+          "name": "--Tests",
+          "usage": [
+            "--Tests <TEST_NAMES>"
+          ],
+          "tip": [
+            "Run tests with names that match the provided values. To provide multiple values, separate them by commas."
+          ],
+          "next": []
+        }
+      ]
+    },
+    {
+      "name": "watch",
+      "tip": [
+        "Start a file watcher that runs a command when files change."
+      ],
+      "option": [
+        {
+          "name": "--arch",
+          "alias": [
+            "-a"
+          ],
+          "usage": [
+            "-a, --arch <ARCH>"
+          ],
+          "tip": [
+            "The target architecture."
+          ],
+          "next": [
+            {
+              "name": "arm64",
+              "tip": [
+                "ARM64"
+              ]
+            },
+            {
+              "name": "x64",
+              "tip": [
+                "64-bit x86"
+              ]
+            },
+            {
+              "name": "x86",
+              "tip": [
+                "32-bit x86"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--artifacts-path",
+          "usage": [
+            "--artifacts-path <ARTIFACTS_DIR>"
+          ],
+          "tip": [
+            "The artifacts path. All output from the project, including build, publish, and pack output, will go in subfolders under the specified path."
+          ],
+          "next": []
+        },
+        {
+          "name": "--configuration",
+          "alias": [
+            "-c"
+          ],
+          "usage": [
+            "-c, --configuration <CONFIGURATION>"
+          ],
+          "tip": [
+            "The configuration to run for. The default for most projects is 'Debug'."
+          ],
+          "next": [
+            {
+              "name": "Debug"
+            },
+            {
+              "name": "Release"
+            }
+          ]
+        },
+        {
+          "name": "--device",
+          "usage": [
+            "--device <DEVICE_ID>"
+          ],
+          "tip": [
+            "The device identifier (for example emulator, simulator or physical device) to run on."
+          ],
+          "next": []
+        },
+        {
+          "name": "--disable-build-servers",
+          "tip": [
+            "Force the command to ignore any persistent build servers."
+          ]
+        },
+        {
+          "name": "--file",
+          "usage": [
+            "--file <FILE_PATH>"
+          ],
+          "tip": [
+            "The path to the file-based app to run (can be also passed as the first argument if there is no project in the current directory)."
+          ],
+          "next": []
+        },
+        {
+          "name": "--framework",
+          "alias": [
+            "-f"
+          ],
+          "usage": [
+            "-f, --framework <FRAMEWORK>"
+          ],
+          "tip": [
+            "The target framework to build for. The target framework must be specified in the project file."
+          ],
+          "next": [
+            {
+              "name": "net10.0",
+              "tip": [
+                ".NET 10"
+              ]
+            },
+            {
+              "name": "net8.0",
+              "tip": [
+                ".NET 8"
+              ]
+            },
+            {
+              "name": "net9.0",
+              "tip": [
+                ".NET 9"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--interactive",
+          "tip": [
+            "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+          ]
+        },
+        {
+          "name": "--launch-profile",
+          "alias": [
+            "-lp"
+          ],
+          "usage": [
+            "-lp, --launch-profile <LAUNCH_PROFILE>"
+          ],
+          "tip": [
+            "The name of the launch profile (if any) to use when launching the application."
+          ],
+          "next": []
+        },
+        {
+          "name": "--list",
+          "tip": [
+            "Lists all discovered files without starting the watcher."
+          ]
+        },
+        {
+          "name": "--no-hot-reload",
+          "tip": [
+            "Suppress hot reload for supported apps."
+          ]
+        },
+        {
+          "name": "--no-launch-profile",
+          "tip": [
+            "Do not attempt to use launchSettings.json or [app].run.json to configure the application."
+          ]
+        },
+        {
+          "name": "--no-restore",
+          "tip": [
+            "Do not restore the project before building."
+          ]
+        },
+        {
+          "name": "--no-self-contained",
+          "tip": [
+            "Publish your application as a framework dependent application. A compatible .NET runtime must be installed on the target machine to run your application."
+          ]
+        },
+        {
+          "name": "--non-interactive",
+          "tip": [
+            "Run dotnet-watch in non-interactive mode. This option is only supported when running with hot reload enabled."
+          ]
+        },
+        {
+          "name": "--os",
+          "usage": [
+            "--os <OS>"
+          ],
+          "tip": [
+            "The target operating system."
+          ],
+          "next": [
+            {
+              "name": "linux",
+              "tip": [
+                "Linux"
+              ]
+            },
+            {
+              "name": "osx",
+              "tip": [
+                "macOS"
+              ]
+            },
+            {
+              "name": "win",
+              "tip": [
+                "Windows"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--project",
+          "usage": [
+            "--project <PROJECT_PATH>"
+          ],
+          "tip": [
+            "Defines the path of the project file to run. If not specified, it defaults to the current directory."
+          ],
+          "next": []
+        },
+        {
+          "name": "--quiet",
+          "alias": [
+            "-q"
+          ],
+          "usage": [
+            "-q, --quiet"
+          ],
+          "tip": [
+            "Suppress all output except warnings and errors."
+          ]
+        },
+        {
+          "name": "--runtime",
+          "alias": [
+            "-r"
+          ],
+          "usage": [
+            "-r, --runtime <RUNTIME_IDENTIFIER>"
+          ],
+          "tip": [
+            "The target runtime to run for."
+          ],
+          "next": [
+            {
+              "name": "linux-x64",
+              "tip": [
+                "Linux x64"
+              ]
+            },
+            {
+              "name": "osx-arm64",
+              "tip": [
+                "macOS ARM64"
+              ]
+            },
+            {
+              "name": "win-x64",
+              "tip": [
+                "Windows x64"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--self-contained",
+          "alias": [
+            "--sc"
+          ],
+          "usage": [
+            "--sc, --self-contained"
+          ],
+          "tip": [
+            "Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.",
+            "The default is 'false.' However, when targeting .NET 7 or lower, the default is 'true' if a runtime identifier is specified."
+          ]
+        },
+        {
+          "name": "--verbose",
+          "tip": [
+            "Show verbose output."
+          ]
+        },
+        {
+          "name": "--verbosity",
+          "alias": [
+            "-verbosity",
+            "-v"
+          ],
+          "usage": [
+            "-v, -verbosity, --verbosity <LEVEL>"
+          ],
+          "tip": [
+            "Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]."
+          ],
+          "next": [
+            {
+              "name": "detailed"
+            },
+            {
+              "name": "diagnostic"
+            },
+            {
+              "name": "minimal"
+            },
+            {
+              "name": "normal"
+            },
+            {
+              "name": "quiet"
+            }
+          ]
+        },
+        {
+          "name": "--version",
+          "tip": [
+            "Display version information."
           ]
         }
       ]
@@ -404,67 +8618,636 @@
     {
       "name": "workload",
       "tip": [
-        "Install or use workloads that extend the .NET experience."
+        "Manage optional workloads."
+      ],
+      "option": [
+        {
+          "name": "--info",
+          "tip": [
+            "Display information about installed workloads."
+          ]
+        },
+        {
+          "name": "--version",
+          "tip": [
+            "Display the currently installed workload version."
+          ]
+        }
       ],
       "next": [
         {
           "name": "clean",
           "tip": [
-            "Removes workload components."
+            "Removes workload components that may have been left behind from previous updates and uninstallations."
+          ],
+          "option": [
+            {
+              "name": "--all",
+              "tip": [
+                "Causes clean to remove and uninstall all workload components from all SDK versions."
+              ]
+            }
           ]
         },
         {
           "name": "config",
           "tip": [
-            "Enables or disables workload-set update mode."
+            "Modify or display workload configuration values.",
+            "To display a value, specify the corresponding command-line option without providing a value. For example: \"dotnet workload config --update-mode\"."
+          ],
+          "option": [
+            {
+              "name": "--update-mode",
+              "usage": [
+                "--update-mode <MANIFESTS|WORKLOAD_SET>"
+              ],
+              "tip": [
+                "Controls whether updates should look for workload sets or the latest version of each individual manifest."
+              ],
+              "next": [
+                {
+                  "name": "manifests"
+                },
+                {
+                  "name": "workload-set"
+                }
+              ]
+            }
           ]
         },
         {
           "name": "history",
           "tip": [
-            "Shows all workload installation actions."
+            "Shows a history of workload installation actions."
           ]
         },
         {
           "name": "install",
+          "usage": [
+            "install <WORKLOAD_ID>"
+          ],
           "tip": [
-            "Installs an optional workload."
+            "Install one or more workloads."
+          ],
+          "option": [
+            {
+              "name": "--configfile",
+              "usage": [
+                "--configfile <FILE>"
+              ],
+              "tip": [
+                "The NuGet configuration file to use."
+              ],
+              "next": []
+            },
+            {
+              "name": "--disable-parallel",
+              "tip": [
+                "Prevent restoring multiple projects in parallel."
+              ]
+            },
+            {
+              "name": "--ignore-failed-sources",
+              "tip": [
+                "Treat package source failures as warnings."
+              ]
+            },
+            {
+              "name": "--include-previews",
+              "tip": [
+                "Allow prerelease workload manifests."
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+              ]
+            },
+            {
+              "name": "--no-http-cache",
+              "tip": [
+                "Do not cache packages and http requests."
+              ]
+            },
+            {
+              "name": "--skip-manifest-update",
+              "tip": [
+                "Skip updating the workload manifests."
+              ]
+            },
+            {
+              "name": "--source",
+              "alias": [
+                "-s"
+              ],
+              "usage": [
+                "-s, --source <SOURCE>"
+              ],
+              "tip": [
+                "The NuGet package source to use during the restore. To specify multiple sources, repeat the option."
+              ],
+              "repeat": 99,
+              "next": []
+            },
+            {
+              "name": "--temp-dir",
+              "usage": [
+                "--temp-dir <TEMP_DIR>"
+              ],
+              "tip": [
+                "Specify a temporary directory for this command to download and extract NuGet packages (must be secure)."
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]. [default: normal]"
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            },
+            {
+              "name": "--version",
+              "usage": [
+                "--version <VERSION>"
+              ],
+              "tip": [
+                "A workload version to display or one or more workloads and their versions joined by the '@' character."
+              ],
+              "next": []
+            }
           ]
         },
         {
           "name": "list",
           "tip": [
-            "Lists all installed workloads."
+            "List workloads available."
           ]
         },
         {
           "name": "repair",
           "tip": [
-            "Repairs all installed workloads."
+            "Repair workload installations."
+          ],
+          "option": [
+            {
+              "name": "--configfile",
+              "usage": [
+                "--configfile <FILE>"
+              ],
+              "tip": [
+                "The NuGet configuration file to use."
+              ],
+              "next": []
+            },
+            {
+              "name": "--disable-parallel",
+              "tip": [
+                "Prevent restoring multiple projects in parallel."
+              ]
+            },
+            {
+              "name": "--ignore-failed-sources",
+              "tip": [
+                "Treat package source failures as warnings."
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+              ]
+            },
+            {
+              "name": "--no-http-cache",
+              "tip": [
+                "Do not cache packages and http requests."
+              ]
+            },
+            {
+              "name": "--source",
+              "alias": [
+                "-s"
+              ],
+              "usage": [
+                "-s, --source <SOURCE>"
+              ],
+              "tip": [
+                "The NuGet package source to use during the restore. To specify multiple sources, repeat the option."
+              ],
+              "repeat": 99,
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]. [default: normal]"
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
           ]
         },
         {
           "name": "restore",
+          "usage": [
+            "restore [<PROJECT | SOLUTION>]"
+          ],
           "tip": [
             "Restore workloads required for a project."
+          ],
+          "option": [
+            {
+              "name": "--configfile",
+              "usage": [
+                "--configfile <FILE>"
+              ],
+              "tip": [
+                "The NuGet configuration file to use."
+              ],
+              "next": []
+            },
+            {
+              "name": "--disable-parallel",
+              "tip": [
+                "Prevent restoring multiple projects in parallel."
+              ]
+            },
+            {
+              "name": "--ignore-failed-sources",
+              "tip": [
+                "Treat package source failures as warnings."
+              ]
+            },
+            {
+              "name": "--include-previews",
+              "tip": [
+                "Allow prerelease workload manifests."
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+              ]
+            },
+            {
+              "name": "--no-http-cache",
+              "tip": [
+                "Do not cache packages and http requests."
+              ]
+            },
+            {
+              "name": "--skip-manifest-update",
+              "tip": [
+                "Skip updating the workload manifests."
+              ]
+            },
+            {
+              "name": "--source",
+              "alias": [
+                "-s"
+              ],
+              "usage": [
+                "-s, --source <SOURCE>"
+              ],
+              "tip": [
+                "The NuGet package source to use during the restore. To specify multiple sources, repeat the option."
+              ],
+              "repeat": 99,
+              "next": []
+            },
+            {
+              "name": "--temp-dir",
+              "usage": [
+                "--temp-dir <TEMP_DIR>"
+              ],
+              "tip": [
+                "Specify a temporary directory for this command to download and extract NuGet packages (must be secure)."
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]. [default: normal]"
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            },
+            {
+              "name": "--version",
+              "usage": [
+                "--version <VERSION>"
+              ],
+              "tip": [
+                "A workload version to display or one or more workloads and their versions joined by the '@' character."
+              ],
+              "next": []
+            }
           ]
         },
         {
           "name": "search",
+          "usage": [
+            "search [<SEARCH_STRING>]"
+          ],
           "tip": [
-            "List selected workloads or all available workloads."
+            "Search for available workloads."
+          ],
+          "next": [
+            {
+              "name": "version",
+              "usage": [
+                "version [<WORKLOAD_VERSION>]"
+              ],
+              "tip": [
+                "Search for available workload versions or what comprises a workload version."
+              ],
+              "option": [
+                {
+                  "name": "--format",
+                  "usage": [
+                    "--format <JSON|LIST>"
+                  ],
+                  "tip": [
+                    "Changes the format of outputted workload versions. Can take 'json' or 'list'."
+                  ],
+                  "next": [
+                    {
+                      "name": "json"
+                    },
+                    {
+                      "name": "list"
+                    }
+                  ]
+                },
+                {
+                  "name": "--include-previews",
+                  "tip": [
+                    "Include preview versions."
+                  ]
+                },
+                {
+                  "name": "--take",
+                  "usage": [
+                    "--take <TAKE>"
+                  ],
+                  "tip": [
+                    "Number of results to provide. [default: 5]"
+                  ],
+                  "next": []
+                }
+              ]
+            }
           ]
         },
         {
           "name": "uninstall",
+          "usage": [
+            "uninstall <WORKLOAD_ID>"
+          ],
           "tip": [
-            "Uninstalls a workload."
+            "Uninstall one or more workloads."
+          ],
+          "option": [
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]. [default: normal]"
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
           ]
         },
         {
           "name": "update",
           "tip": [
-            "Reinstalls all installed workloads."
+            "Update all installed workloads."
+          ],
+          "option": [
+            {
+              "name": "--advertising-manifests-only",
+              "tip": [
+                "Only update advertising manifests."
+              ]
+            },
+            {
+              "name": "--configfile",
+              "usage": [
+                "--configfile <FILE>"
+              ],
+              "tip": [
+                "The NuGet configuration file to use."
+              ],
+              "next": []
+            },
+            {
+              "name": "--disable-parallel",
+              "tip": [
+                "Prevent restoring multiple projects in parallel."
+              ]
+            },
+            {
+              "name": "--from-history",
+              "usage": [
+                "--from-history <VERSION>"
+              ],
+              "tip": [
+                "Update workloads to a previous version specified by the argument. Use the 'dotnet workload history' to see available workload history records."
+              ],
+              "next": []
+            },
+            {
+              "name": "--from-previous-sdk",
+              "tip": [
+                "Include workloads installed with earlier SDK versions in update."
+              ]
+            },
+            {
+              "name": "--ignore-failed-sources",
+              "tip": [
+                "Treat package source failures as warnings."
+              ]
+            },
+            {
+              "name": "--include-previews",
+              "tip": [
+                "Allow prerelease workload manifests."
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+              ]
+            },
+            {
+              "name": "--manifests-only",
+              "usage": [
+                "--manifests-only <VERSION>"
+              ],
+              "tip": [
+                "Update to the workload versions specified in the history without changing which workloads are installed."
+              ],
+              "next": []
+            },
+            {
+              "name": "--no-http-cache",
+              "tip": [
+                "Do not cache packages and http requests."
+              ]
+            },
+            {
+              "name": "--source",
+              "alias": [
+                "-s"
+              ],
+              "usage": [
+                "-s, --source <SOURCE>"
+              ],
+              "tip": [
+                "The NuGet package source to use during the restore. To specify multiple sources, repeat the option."
+              ],
+              "repeat": 99,
+              "next": []
+            },
+            {
+              "name": "--temp-dir",
+              "usage": [
+                "--temp-dir <TEMP_DIR>"
+              ],
+              "tip": [
+                "Specify a temporary directory for this command to download and extract NuGet packages (must be secure)."
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]. [default: normal]"
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            },
+            {
+              "name": "--version",
+              "usage": [
+                "--version <VERSION>"
+              ],
+              "tip": [
+                "A workload version to display or one or more workloads and their versions joined by the '@' character."
+              ],
+              "next": []
+            }
           ]
         }
       ]
@@ -474,46 +9257,51 @@
     {
       "name": "--info",
       "tip": [
-        "Prints out detailed information about a .NET installation and the machine environment,",
-        "such as the current operating system, and commit SHA of the .NET version."
+        "Display .NET information."
       ]
     },
     {
       "name": "--list-runtimes",
       "tip": [
-        "Prints out a list of the installed .NET runtimes for the architecture of the invoked dotnet."
+        "Display the installed runtimes."
       ]
     },
     {
       "name": "--list-sdks",
       "tip": [
-        "Prints out a list of the installed .NET SDKs for the architecture of the invoked dotnet. "
+        "Display the installed SDKs."
       ]
     },
     {
       "name": "--version",
       "tip": [
-        "Prints out the version of the .NET SDK used by dotnet commands.",
-        "It may be affected by a global.json file.",
-        "Available only when the SDK is installed."
+        "Display .NET SDK version in use."
       ]
     }
   ],
   "global_option": [
     {
       "name": "--additional-deps",
+      "usage": [
+        "--additional-deps <PATH>"
+      ],
       "tip": [
-        "Path to an additional .deps.json file. ",
-        "A deps.json file contains a list of dependencies, compilation dependencies,",
-        "and version information used to address assembly conflicts."
-      ]
+        "Path to an additional deps.json file.",
+        "A deps.json file contains a list of dependencies, compilation dependencies, and version information used to address assembly conflicts."
+      ],
+      "next": []
     },
     {
       "name": "--additionalprobingpath",
+      "usage": [
+        "--additionalprobingpath <PATH>"
+      ],
       "tip": [
-        "Path containing probing policy and assemblies to probe.",
+        "Path containing probing policy and assemblies to probe for.",
         "Repeat the option to specify multiple paths."
-      ]
+      ],
+      "repeat": 99,
+      "next": []
     },
     {
       "name": "--diagnostics",
@@ -524,14 +9312,18 @@
         "-d, --diagnostics"
       ],
       "tip": [
-        "Enables diagnostic output."
+        "Enable diagnostic output."
       ]
     },
     {
       "name": "--fx-version",
+      "usage": [
+        "--fx-version <VERSION>"
+      ],
       "tip": [
-        "Version of the .NET runtime to use to run the application."
-      ]
+        "Version of the installed Shared Framework to use to run the application."
+      ],
+      "next": []
     },
     {
       "name": "--help",
@@ -543,7 +9335,7 @@
         "-?, -h, --help"
       ],
       "tip": [
-        "Prints out documentation for a given command."
+        "Show command line help."
       ]
     },
     {
@@ -552,10 +9344,8 @@
         "--roll-forward <SETTING>"
       ],
       "tip": [
-        "Controls how roll forward is applied to the app.",
-        "The SETTING can be one of the following values.",
-        "If not specified, Minor is the default.",
-        "[LatestPatch|Minor|Major|LatestMinor|LatestMajor|Disable]"
+        "Roll forward to framework version (LatestPatch, Minor, LatestMinor, Major, LatestMajor, Disable).",
+        "If not specified, Minor is the default."
       ],
       "next": [
         {
@@ -584,12 +9374,29 @@
         "-v"
       ],
       "usage": [
-        "-v, --verbosity"
+        "-v, --verbosity <LEVEL>"
       ],
       "tip": [
         "Sets the verbosity level of the command.",
         "Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].",
         "Not supported in every command."
+      ],
+      "next": [
+        {
+          "name": "detailed"
+        },
+        {
+          "name": "diagnostic"
+        },
+        {
+          "name": "minimal"
+        },
+        {
+          "name": "normal"
+        },
+        {
+          "name": "quiet"
+        }
       ]
     }
   ]

--- a/completions/dotnet/language/zh-CN.json
+++ b/completions/dotnet/language/zh-CN.json
@@ -9,41 +9,1215 @@
     {
       "name": "build",
       "tip": [
-        "生成 .NET 应用程序。"
+        "生成 .NET 项目。"
+      ],
+      "option": [
+        {
+          "name": "--arch",
+          "alias": [
+            "-a"
+          ],
+          "usage": [
+            "-a, --arch <ARCH>"
+          ],
+          "tip": [
+            "目标体系结构。"
+          ],
+          "next": [
+            {
+              "name": "arm",
+              "tip": [
+                "ARM32 "
+              ]
+            },
+            {
+              "name": "arm64",
+              "tip": [
+                "ARM64 "
+              ]
+            },
+            {
+              "name": "x64",
+              "tip": [
+                "64 位 x86"
+              ]
+            },
+            {
+              "name": "x86",
+              "tip": [
+                "32 位 x86"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--artifacts-path",
+          "usage": [
+            "--artifacts-path <ARTIFACTS_DIR>"
+          ],
+          "tip": [
+            "产物路径。项目的所有输出（包括生成、发布和打包输出）都将放到指定路径下的子文件夹中。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--configuration",
+          "alias": [
+            "-c"
+          ],
+          "usage": [
+            "-c, --configuration <CONFIGURATION>"
+          ],
+          "tip": [
+            "用于生成项目的配置。大多数项目的默认值为 'Debug'。"
+          ],
+          "next": [
+            {
+              "name": "Debug"
+            },
+            {
+              "name": "Release"
+            }
+          ]
+        },
+        {
+          "name": "--disable-build-servers",
+          "tip": [
+            "强制命令忽略任何永久性生成服务器。"
+          ]
+        },
+        {
+          "name": "--framework",
+          "alias": [
+            "-f"
+          ],
+          "usage": [
+            "-f, --framework <FRAMEWORK>"
+          ],
+          "tip": [
+            "要为其生成的目标框架。项目文件中还必须指定目标框架。"
+          ],
+          "next": [
+            {
+              "name": "net10.0",
+              "tip": [
+                ".NET 10 "
+              ]
+            },
+            {
+              "name": "net8.0",
+              "tip": [
+                ".NET 8 "
+              ]
+            },
+            {
+              "name": "net9.0",
+              "tip": [
+                ".NET 9 "
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--interactive",
+          "tip": [
+            "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+          ]
+        },
+        {
+          "name": "--no-dependencies",
+          "tip": [
+            "不生成项目到项目的引用，仅生成指定的项目。"
+          ]
+        },
+        {
+          "name": "--no-incremental",
+          "tip": [
+            "不使用增量生成。"
+          ]
+        },
+        {
+          "name": "--no-logo",
+          "alias": [
+            "-nologo"
+          ],
+          "usage": [
+            "-nologo, --no-logo"
+          ],
+          "tip": [
+            "不显示启动横幅或版权消息。"
+          ]
+        },
+        {
+          "name": "--no-restore",
+          "tip": [
+            "生成前不还原项目。"
+          ]
+        },
+        {
+          "name": "--no-self-contained",
+          "tip": [
+            "将应用程序发布为依赖框架的应用程序。目标计算机上必须安装兼容的 .NET 运行时才能运行该应用程序。"
+          ]
+        },
+        {
+          "name": "--os",
+          "usage": [
+            "--os <OS>"
+          ],
+          "tip": [
+            "目标操作系统。"
+          ],
+          "next": [
+            {
+              "name": "linux",
+              "tip": [
+                "Linux "
+              ]
+            },
+            {
+              "name": "osx",
+              "tip": [
+                "macOS "
+              ]
+            },
+            {
+              "name": "win",
+              "tip": [
+                "Windows "
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--output",
+          "alias": [
+            "-o"
+          ],
+          "usage": [
+            "-o, --output <OUTPUT_DIR>"
+          ],
+          "tip": [
+            "放置生成产物的输出目录。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--runtime",
+          "alias": [
+            "-r"
+          ],
+          "usage": [
+            "-r, --runtime <RUNTIME_IDENTIFIER>"
+          ],
+          "tip": [
+            "要为其生成的目标运行时。"
+          ],
+          "next": [
+            {
+              "name": "linux-arm64",
+              "tip": [
+                "Linux ARM64 "
+              ]
+            },
+            {
+              "name": "linux-x64",
+              "tip": [
+                "Linux x64 "
+              ]
+            },
+            {
+              "name": "osx-arm64",
+              "tip": [
+                "macOS ARM64 "
+              ]
+            },
+            {
+              "name": "osx-x64",
+              "tip": [
+                "macOS x64 "
+              ]
+            },
+            {
+              "name": "win-arm64",
+              "tip": [
+                "Windows ARM64 "
+              ]
+            },
+            {
+              "name": "win-x64",
+              "tip": [
+                "Windows x64 "
+              ]
+            },
+            {
+              "name": "win-x86",
+              "tip": [
+                "Windows x86 "
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--self-contained",
+          "alias": [
+            "--sc"
+          ],
+          "usage": [
+            "--sc, --self-contained"
+          ],
+          "tip": [
+            "随应用程序发布 .NET 运行时，这样无需在目标计算机上安装运行时。",
+            "默认值为 'false'。但在面向 .NET 7 或更低版本时，如果指定了运行时标识符，默认值为 'true'。"
+          ]
+        },
+        {
+          "name": "--use-current-runtime",
+          "alias": [
+            "--ucr"
+          ],
+          "usage": [
+            "--ucr, --use-current-runtime"
+          ],
+          "tip": [
+            "使用当前运行时作为目标运行时。"
+          ]
+        },
+        {
+          "name": "--verbosity",
+          "alias": [
+            "-verbosity",
+            "-v"
+          ],
+          "usage": [
+            "-v, -verbosity, --verbosity <LEVEL>"
+          ],
+          "tip": [
+            "设置 MSBuild 详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。"
+          ],
+          "next": [
+            {
+              "name": "detailed"
+            },
+            {
+              "name": "diagnostic"
+            },
+            {
+              "name": "minimal"
+            },
+            {
+              "name": "normal"
+            },
+            {
+              "name": "quiet"
+            }
+          ]
+        },
+        {
+          "name": "--version-suffix",
+          "usage": [
+            "--version-suffix <VERSION_SUFFIX>"
+          ],
+          "tip": [
+            "设置生成项目时使用的 $(VersionSuffix) 属性的值。"
+          ],
+          "next": []
+        }
       ]
     },
     {
       "name": "build-server",
       "tip": [
-        "与由生成操作启动的服务器进行交互。"
+        "与由生成版本启动的服务器进行交互。"
+      ],
+      "next": [
+        {
+          "name": "shutdown",
+          "tip": [
+            "关闭由 dotnet 启动的生成服务器。默认情况下会关闭所有服务器。"
+          ],
+          "option": [
+            {
+              "name": "--msbuild",
+              "tip": [
+                "关闭 MSBuild 生成服务器。"
+              ]
+            },
+            {
+              "name": "--razor",
+              "tip": [
+                "关闭 Razor 生成服务器。"
+              ]
+            },
+            {
+              "name": "--vbcscompiler",
+              "tip": [
+                "关闭 VB/C# 编译器生成服务器。"
+              ]
+            }
+          ]
+        }
       ]
     },
     {
       "name": "clean",
       "tip": [
-        "清除生成输出。"
-      ]
-    },
-    {
-      "name": "exec",
-      "tip": [
-        "运行 .NET 应用程序。"
+        "清理 .NET 项目的生成输出。"
       ],
       "option": [
         {
-          "name": "--depsfile",
+          "name": "--artifacts-path",
+          "usage": [
+            "--artifacts-path <ARTIFACTS_DIR>"
+          ],
           "tip": [
-            "deps.json 文件的路径。",
-            "deps.json 文件包含运行应用程序所需的依赖项信息。",
-            "此文件由 .NET SDK 生成。"
+            "产物路径。项目的所有输出（包括生成、发布和打包输出）都将放到指定路径下的子文件夹中。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--configuration",
+          "alias": [
+            "-c"
+          ],
+          "usage": [
+            "-c, --configuration <CONFIGURATION>"
+          ],
+          "tip": [
+            "要清理的配置。大多数项目的默认值为 'Debug'。"
+          ],
+          "next": [
+            {
+              "name": "Debug"
+            },
+            {
+              "name": "Release"
+            }
           ]
         },
         {
-          "name": "--runtimeconfig",
+          "name": "--disable-build-servers",
           "tip": [
-            "runtimeconfig.json 文件的路径。",
-            "runtimeconfig.json 文件包含运行时设置。",
-            "通常命名为 <应用程序名称>.runtimeconfig.json。"
+            "强制命令忽略任何永久性生成服务器。"
+          ]
+        },
+        {
+          "name": "--framework",
+          "alias": [
+            "-f"
+          ],
+          "usage": [
+            "-f, --framework <FRAMEWORK>"
+          ],
+          "tip": [
+            "要清理的目标框架。项目文件中还必须指定目标框架。"
+          ],
+          "next": [
+            {
+              "name": "net10.0",
+              "tip": [
+                ".NET 10 "
+              ]
+            },
+            {
+              "name": "net8.0",
+              "tip": [
+                ".NET 8 "
+              ]
+            },
+            {
+              "name": "net9.0",
+              "tip": [
+                ".NET 9 "
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--interactive",
+          "tip": [
+            "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+          ]
+        },
+        {
+          "name": "--no-logo",
+          "alias": [
+            "-nologo"
+          ],
+          "usage": [
+            "-nologo, --no-logo"
+          ],
+          "tip": [
+            "不显示启动横幅或版权消息。"
+          ]
+        },
+        {
+          "name": "--output",
+          "alias": [
+            "-o"
+          ],
+          "usage": [
+            "-o, --output <OUTPUT_DIR>"
+          ],
+          "tip": [
+            "包含要清理的生成产物的目录。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--runtime",
+          "alias": [
+            "-r"
+          ],
+          "usage": [
+            "-r, --runtime <RUNTIME_IDENTIFIER>"
+          ],
+          "tip": [
+            "要为其清理的目标运行时。"
+          ],
+          "next": [
+            {
+              "name": "linux-x64",
+              "tip": [
+                "Linux x64 "
+              ]
+            },
+            {
+              "name": "osx-arm64",
+              "tip": [
+                "macOS ARM64 "
+              ]
+            },
+            {
+              "name": "win-x64",
+              "tip": [
+                "Windows x64 "
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--verbosity",
+          "alias": [
+            "-v"
+          ],
+          "usage": [
+            "-v, --verbosity <LEVEL>"
+          ],
+          "tip": [
+            "设置 MSBuild 详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。[默认值: normal]"
+          ],
+          "next": [
+            {
+              "name": "detailed"
+            },
+            {
+              "name": "diagnostic"
+            },
+            {
+              "name": "minimal"
+            },
+            {
+              "name": "normal"
+            },
+            {
+              "name": "quiet"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "dev-certs",
+      "tip": [
+        "创建和管理开发证书。"
+      ],
+      "next": [
+        {
+          "name": "https",
+          "usage": [
+            "https [options]"
+          ],
+          "tip": [
+            "创建、信任和导出 HTTPS 开发证书。"
+          ],
+          "option": [
+            {
+              "name": "--check",
+              "alias": [
+                "-c"
+              ],
+              "usage": [
+                "-c, --check"
+              ],
+              "tip": [
+                "检查证书是否存在，但不执行任何操作。"
+              ]
+            },
+            {
+              "name": "--check-trust-machine-readable",
+              "tip": [
+                "与运行 --check --trust 相同，但以 json 输出结果。"
+              ]
+            },
+            {
+              "name": "--clean",
+              "tip": [
+                "清除计算机上的所有 HTTPS 开发证书。"
+              ]
+            },
+            {
+              "name": "--export-path",
+              "alias": [
+                "-ep"
+              ],
+              "usage": [
+                "-ep, --export-path <PATH>"
+              ],
+              "tip": [
+                "已导出证书的完整路径。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--format",
+              "usage": [
+                "--format <PFX|PEM>"
+              ],
+              "tip": [
+                "以给定格式导出证书。有效值为 Pfx 和 Pem。Pfx 是默认值。"
+              ],
+              "next": [
+                {
+                  "name": "Pem"
+                },
+                {
+                  "name": "Pfx"
+                }
+              ]
+            },
+            {
+              "name": "--import",
+              "alias": [
+                "-i"
+              ],
+              "usage": [
+                "-i, --import"
+              ],
+              "tip": [
+                "将提供的 HTTPS 开发证书导入计算机。所有其他 HTTPS 开发证书都将被清除。"
+              ]
+            },
+            {
+              "name": "--no-password",
+              "alias": [
+                "-np"
+              ],
+              "usage": [
+                "-np, --no-password"
+              ],
+              "tip": [
+                "明确要求以 PEM 格式导出证书时不使用密钥密码。"
+              ]
+            },
+            {
+              "name": "--password",
+              "alias": [
+                "-p"
+              ],
+              "usage": [
+                "-p, --password <PASSWORD>"
+              ],
+              "tip": [
+                "将证书与私钥导出到 pfx 文件或加密 Pem 导出的密钥时使用的密码。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--quiet",
+              "alias": [
+                "-q"
+              ],
+              "usage": [
+                "-q, --quiet"
+              ],
+              "tip": [
+                "仅显示警告和错误。"
+              ]
+            },
+            {
+              "name": "--trust",
+              "alias": [
+                "-t"
+              ],
+              "usage": [
+                "-t, --trust"
+              ],
+              "tip": [
+                "当不与 --check 选项结合使用时，在当前平台上信任证书，如果必要则创建一个。",
+                "当与 --check 选项结合使用时，验证存在证书且受信任。"
+              ]
+            },
+            {
+              "name": "--verbose",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbose"
+              ],
+              "tip": [
+                "显示更多调试信息。"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "format",
+      "tip": [
+        "将样式首选项应用到项目或解决方案。"
+      ],
+      "option": [
+        {
+          "name": "--binarylog",
+          "usage": [
+            "--binarylog <BINARY_LOG_PATH>"
+          ],
+          "tip": [
+            "将所有项目或解决方案加载信息记录到二进制日志文件中。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--diagnostics",
+          "usage": [
+            "--diagnostics <DIAGNOSTICS>"
+          ],
+          "tip": [
+            "修复代码样式或第三方问题时用作筛选器的诊断 ID 列表（以空格分隔）。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--exclude",
+          "usage": [
+            "--exclude <EXCLUDE>"
+          ],
+          "tip": [
+            "不进行格式化的文件或文件夹的相对路径列表。"
+          ],
+          "repeat": 99,
+          "next": []
+        },
+        {
+          "name": "--exclude-diagnostics",
+          "usage": [
+            "--exclude-diagnostics <DIAGNOSTICS>"
+          ],
+          "tip": [
+            "修复代码样式或第三方问题时要忽略的诊断 ID 列表（以空格分隔）。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--include",
+          "usage": [
+            "--include <INCLUDE>"
+          ],
+          "tip": [
+            "要进行格式化的文件或文件夹的相对路径列表。如果为空，则格式化所有文件。"
+          ],
+          "repeat": 99,
+          "next": []
+        },
+        {
+          "name": "--include-generated",
+          "tip": [
+            "格式化 SDK 生成的文件。"
+          ]
+        },
+        {
+          "name": "--no-restore",
+          "tip": [
+            "格式化前不执行隐式还原。"
+          ]
+        },
+        {
+          "name": "--report",
+          "usage": [
+            "--report <REPORT_PATH>"
+          ],
+          "tip": [
+            "接受将在给定目录中生成 JSON 报表的文件路径（如果提供）。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--severity",
+          "usage": [
+            "--severity <SEVERITY>"
+          ],
+          "tip": [
+            "要修复的诊断的严重性。允许的值为 info、warn 和 error。"
+          ],
+          "next": [
+            {
+              "name": "error"
+            },
+            {
+              "name": "hidden"
+            },
+            {
+              "name": "info"
+            },
+            {
+              "name": "warn"
+            }
+          ]
+        },
+        {
+          "name": "--verbosity",
+          "alias": [
+            "-v"
+          ],
+          "usage": [
+            "-v, --verbosity <LEVEL>"
+          ],
+          "tip": [
+            "设置详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。"
+          ],
+          "next": [
+            {
+              "name": "detailed"
+            },
+            {
+              "name": "diagnostic"
+            },
+            {
+              "name": "minimal"
+            },
+            {
+              "name": "normal"
+            },
+            {
+              "name": "quiet"
+            }
+          ]
+        },
+        {
+          "name": "--verify-no-changes",
+          "tip": [
+            "验证不会执行任何格式更改。如果任何文件已被格式化，则以非零退出代码终止。"
+          ]
+        },
+        {
+          "name": "--version",
+          "tip": [
+            "显示版本信息。"
+          ]
+        }
+      ],
+      "next": [
+        {
+          "name": "analyzers",
+          "usage": [
+            "analyzers [<PROJECT | SOLUTION>]"
+          ],
+          "tip": [
+            "运行第三方分析器并应用修补程序。"
+          ]
+        },
+        {
+          "name": "style",
+          "usage": [
+            "style [<PROJECT | SOLUTION>]"
+          ],
+          "tip": [
+            "运行代码样式分析器并应用修补程序。"
+          ]
+        },
+        {
+          "name": "whitespace",
+          "usage": [
+            "whitespace [<PROJECT | SOLUTION>]"
+          ],
+          "tip": [
+            "运行空白格式设置。"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "fsi",
+      "tip": [
+        "启动 F# 交互式 / 执行 F# 脚本。"
+      ],
+      "option": [
+        {
+          "name": "--checked",
+          "usage": [
+            "--checked[+|-]"
+          ],
+          "tip": [
+            "生成溢出检查（默认关闭）。"
+          ],
+          "next": [
+            {
+              "name": "-"
+            },
+            {
+              "name": "+"
+            }
+          ]
+        },
+        {
+          "name": "--codepage",
+          "usage": [
+            "--codepage:<n>"
+          ],
+          "tip": [
+            "指定用于读取源文件的代码页。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--compilertool",
+          "alias": [
+            "-t"
+          ],
+          "usage": [
+            "-t, --compilertool:<file>"
+          ],
+          "tip": [
+            "引用包含设计时工具的程序集或目录。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--debug",
+          "alias": [
+            "-g"
+          ],
+          "usage": [
+            "-g, --debug[+|-]"
+          ],
+          "tip": [
+            "发出调试信息（默认开启）。"
+          ],
+          "next": [
+            {
+              "name": "-"
+            },
+            {
+              "name": "+"
+            },
+            {
+              "name": "embedded"
+            },
+            {
+              "name": "full"
+            },
+            {
+              "name": "pdbonly"
+            },
+            {
+              "name": "portable"
+            }
+          ]
+        },
+        {
+          "name": "--define",
+          "alias": [
+            "-d"
+          ],
+          "usage": [
+            "-d, --define:<string>"
+          ],
+          "tip": [
+            "定义条件编译符号。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--deterministic",
+          "usage": [
+            "--deterministic[+|-]"
+          ],
+          "tip": [
+            "生成确定性程序集（默认关闭）。"
+          ],
+          "next": [
+            {
+              "name": "-"
+            },
+            {
+              "name": "+"
+            }
+          ]
+        },
+        {
+          "name": "--exec",
+          "tip": [
+            "在加载文件或运行命令行上给定的 .fsx 脚本后退出 fsi。"
+          ]
+        },
+        {
+          "name": "--langversion",
+          "usage": [
+            "--langversion:<VERSION>"
+          ],
+          "tip": [
+            "指定语言版本，如 \"latest\" 或 \"preview\"。"
+          ],
+          "next": [
+            {
+              "name": "latest"
+            },
+            {
+              "name": "preview"
+            }
+          ]
+        },
+        {
+          "name": "--lib",
+          "alias": [
+            "-I"
+          ],
+          "usage": [
+            "-I, --lib:<dir;...>"
+          ],
+          "tip": [
+            "为用于解析源文件和程序集的包含路径指定目录。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--load",
+          "usage": [
+            "--load:<file>"
+          ],
+          "tip": [
+            "在启动时 #load 给定文件。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--multiemit",
+          "usage": [
+            "--multiemit[+|-]"
+          ],
+          "tip": [
+            "发出多个程序集（默认开启）。"
+          ],
+          "next": [
+            {
+              "name": "-"
+            },
+            {
+              "name": "+"
+            }
+          ]
+        },
+        {
+          "name": "--nologo",
+          "tip": [
+            "取消显示编译器版权横幅。"
+          ]
+        },
+        {
+          "name": "--nowarn",
+          "usage": [
+            "--nowarn:<warn;...>"
+          ],
+          "tip": [
+            "禁用特定的警告消息。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--optimize",
+          "alias": [
+            "-O"
+          ],
+          "usage": [
+            "-O, --optimize[+|-]"
+          ],
+          "tip": [
+            "启用优化（默认开启）。"
+          ],
+          "next": [
+            {
+              "name": "-"
+            },
+            {
+              "name": "+"
+            }
+          ]
+        },
+        {
+          "name": "--quiet",
+          "tip": [
+            "禁止 fsi 写入 stdout。"
+          ]
+        },
+        {
+          "name": "--readline",
+          "usage": [
+            "--readline[+|-]"
+          ],
+          "tip": [
+            "在控制台中支持 TAB 补全（默认开启）。"
+          ],
+          "next": [
+            {
+              "name": "-"
+            },
+            {
+              "name": "+"
+            }
+          ]
+        },
+        {
+          "name": "--reference",
+          "alias": [
+            "-r"
+          ],
+          "usage": [
+            "-r, --reference:<file>"
+          ],
+          "tip": [
+            "引用一个程序集。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--tailcalls",
+          "usage": [
+            "--tailcalls[+|-]"
+          ],
+          "tip": [
+            "启用或禁用尾调用（默认开启）。"
+          ],
+          "next": [
+            {
+              "name": "-"
+            },
+            {
+              "name": "+"
+            }
+          ]
+        },
+        {
+          "name": "--targetprofile",
+          "usage": [
+            "--targetprofile:<string>"
+          ],
+          "tip": [
+            "指定此程序集的目标框架配置文件。有效值为 mscorlib、netcore 或 netstandard。默认：mscorlib。"
+          ],
+          "next": [
+            {
+              "name": "mscorlib"
+            },
+            {
+              "name": "netcore"
+            },
+            {
+              "name": "netstandard"
+            }
+          ]
+        },
+        {
+          "name": "--typecheck-only",
+          "tip": [
+            "仅执行类型检查，不执行代码。"
+          ]
+        },
+        {
+          "name": "--use",
+          "usage": [
+            "--use:<file>"
+          ],
+          "tip": [
+            "在启动时使用给定文件作为初始输入。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--usesdkrefs",
+          "usage": [
+            "--usesdkrefs[+|-]"
+          ],
+          "tip": [
+            "如果可用，对 .NET Framework 引用使用引用程序集（默认启用）。"
+          ],
+          "next": [
+            {
+              "name": "-"
+            },
+            {
+              "name": "+"
+            }
+          ]
+        },
+        {
+          "name": "--utf8output",
+          "tip": [
+            "以 UTF-8 编码输出消息。"
+          ]
+        },
+        {
+          "name": "--version",
+          "tip": [
+            "显示编译器版本横幅并退出。"
+          ]
+        },
+        {
+          "name": "--warn",
+          "usage": [
+            "--warn:<level>"
+          ],
+          "tip": [
+            "设置警告等级（0-5）。"
+          ],
+          "next": [
+            {
+              "name": "0"
+            },
+            {
+              "name": "1"
+            },
+            {
+              "name": "2"
+            },
+            {
+              "name": "3"
+            },
+            {
+              "name": "4"
+            },
+            {
+              "name": "5"
+            }
+          ]
+        },
+        {
+          "name": "--warnaserror",
+          "usage": [
+            "--warnaserror[+|-]"
+          ],
+          "tip": [
+            "将所有警告报告为错误（默认关闭）。"
+          ],
+          "next": [
+            {
+              "name": "-"
+            },
+            {
+              "name": "+"
+            }
           ]
         }
       ]
@@ -51,25 +1225,486 @@
     {
       "name": "help",
       "tip": [
-        "在线显示该命令更详细的文档。"
+        "在浏览器中打开指定命令的参考页。"
       ]
     },
     {
       "name": "msbuild",
       "tip": [
-        "提供对 MSBuild 命令行工具的访问。"
+        "运行 Microsoft 生成引擎（MSBuild）命令。"
+      ],
+      "option": [
+        {
+          "name": "-binaryLogger",
+          "alias": [
+            "-bl"
+          ],
+          "usage": [
+            "-bl, -binaryLogger [LOGFILE]"
+          ],
+          "tip": [
+            "将所有生成事件序列化到压缩的二进制文件中。"
+          ],
+          "next": []
+        },
+        {
+          "name": "-check",
+          "tip": [
+            "如果项目配置无效，则报错。"
+          ]
+        },
+        {
+          "name": "-consoleLoggerParameters",
+          "alias": [
+            "-clp"
+          ],
+          "usage": [
+            "-clp, -consoleLoggerParameters <PARAMETERS>"
+          ],
+          "tip": [
+            "控制台记录器的参数。可用参数包括 PerformanceSummary、Summary、NoSummary、ErrorsOnly、WarningsOnly 等。"
+          ],
+          "next": []
+        },
+        {
+          "name": "-detailedSummary",
+          "usage": [
+            "-detailedSummary [TRUE|FALSE]"
+          ],
+          "tip": [
+            "在生成结束时显示详细的生成摘要信息。"
+          ],
+          "next": [
+            {
+              "name": "False"
+            },
+            {
+              "name": "True"
+            }
+          ]
+        },
+        {
+          "name": "-distributedFileLogger",
+          "alias": [
+            "-dfl"
+          ],
+          "usage": [
+            "-dfl, -distributedFileLogger"
+          ],
+          "tip": [
+            "将每个 MSBuild 节点的生成输出记录到其自己的文件中。"
+          ]
+        },
+        {
+          "name": "-distributedLogger",
+          "alias": [
+            "-dl"
+          ],
+          "usage": [
+            "-dl, -distributedLogger <CENTRAL_LOGGER>*<FORWARDING_LOGGER>"
+          ],
+          "tip": [
+            "使用此记录器记录 MSBuild 的事件，并为每个节点附加不同的记录器实例。"
+          ],
+          "next": []
+        },
+        {
+          "name": "-fileLogger",
+          "alias": [
+            "-fl"
+          ],
+          "usage": [
+            "-fl, -fileLogger"
+          ],
+          "tip": [
+            "将生成输出记录到文件中。默认情况下，文件名为当前目录中的 msbuild.log。"
+          ]
+        },
+        {
+          "name": "-fileLoggerParameters",
+          "alias": [
+            "-flp"
+          ],
+          "usage": [
+            "-flp, -fileLoggerParameters <PARAMETERS>"
+          ],
+          "tip": [
+            "文件记录器的参数。"
+          ],
+          "next": []
+        },
+        {
+          "name": "-getItem",
+          "usage": [
+            "-getItem <ITEMNAME,...>"
+          ],
+          "tip": [
+            "获取指定一个或多个项类型的项。"
+          ],
+          "next": []
+        },
+        {
+          "name": "-getProperty",
+          "usage": [
+            "-getProperty <PROPERTYNAME,...>"
+          ],
+          "tip": [
+            "获取指定一个或多个属性的值。"
+          ],
+          "next": []
+        },
+        {
+          "name": "-getResultOutputFile",
+          "usage": [
+            "-getResultOutputFile <FILE>"
+          ],
+          "tip": [
+            "获取结果输出文件将使用的默认路径。"
+          ],
+          "next": []
+        },
+        {
+          "name": "-getTargetResult",
+          "usage": [
+            "-getTargetResult <TARGETNAME,...>"
+          ],
+          "tip": [
+            "获取指定一个或多个目标的结果。"
+          ],
+          "next": []
+        },
+        {
+          "name": "-graphBuild",
+          "usage": [
+            "-graphBuild [TRUE|FALSE]"
+          ],
+          "tip": [
+            "指示 MSBuild 构造并生成项目图。"
+          ],
+          "next": [
+            {
+              "name": "False"
+            },
+            {
+              "name": "True"
+            }
+          ]
+        },
+        {
+          "name": "-ignoreProjectExtensions",
+          "usage": [
+            "-ignoreProjectExtensions <EXTENSIONS>"
+          ],
+          "tip": [
+            "确定要使用的项目文件时忽略指定的扩展名。"
+          ],
+          "next": []
+        },
+        {
+          "name": "-interactive",
+          "usage": [
+            "-interactive [TRUE|FALSE]"
+          ],
+          "tip": [
+            "指示生成将允许交互式用户输入。"
+          ],
+          "next": [
+            {
+              "name": "False"
+            },
+            {
+              "name": "True"
+            }
+          ]
+        },
+        {
+          "name": "-isolateProjects",
+          "usage": [
+            "-isolateProjects [TRUE|MESSAGEUPONISOLATIONVIOLATION|FALSE]"
+          ],
+          "tip": [
+            "指示 MSBuild 隔离项目以实现生成隔离。"
+          ],
+          "next": [
+            {
+              "name": "False"
+            },
+            {
+              "name": "MessageUponIsolationViolation"
+            },
+            {
+              "name": "True"
+            }
+          ]
+        },
+        {
+          "name": "-logger",
+          "alias": [
+            "-l"
+          ],
+          "usage": [
+            "-l, -logger <LOGGER>"
+          ],
+          "tip": [
+            "使用此记录器记录 MSBuild 的事件。若要指定多个记录器，请分别指定每个记录器。"
+          ],
+          "repeat": 99,
+          "next": []
+        },
+        {
+          "name": "-lowPriority",
+          "usage": [
+            "-lowPriority [TRUE|FALSE]"
+          ],
+          "tip": [
+            "以较低的进程优先级运行生成。"
+          ],
+          "next": [
+            {
+              "name": "False"
+            },
+            {
+              "name": "True"
+            }
+          ]
+        },
+        {
+          "name": "-maxCpuCount",
+          "alias": [
+            "-m"
+          ],
+          "usage": [
+            "-m, -maxCpuCount [N]"
+          ],
+          "tip": [
+            "指定生成时使用的最大并发进程数。"
+          ],
+          "next": []
+        },
+        {
+          "name": "-noAutoResponse",
+          "tip": [
+            "不自动包含任何 MSBuild.rsp 文件。"
+          ]
+        },
+        {
+          "name": "-noConsoleLogger",
+          "tip": [
+            "禁用默认的控制台记录器，并且不将事件记录到控制台。"
+          ]
+        },
+        {
+          "name": "-nodeReuse",
+          "alias": [
+            "-nr"
+          ],
+          "usage": [
+            "-nr, -nodeReuse <TRUE|FALSE>"
+          ],
+          "tip": [
+            "启用或禁用 MSBuild 节点的重用。"
+          ],
+          "next": [
+            {
+              "name": "False"
+            },
+            {
+              "name": "True"
+            }
+          ]
+        },
+        {
+          "name": "-noLogo",
+          "usage": [
+            "-noLogo [TRUE|FALSE]"
+          ],
+          "tip": [
+            "不显示启动横幅和版权消息。"
+          ],
+          "next": [
+            {
+              "name": "False"
+            },
+            {
+              "name": "True"
+            }
+          ]
+        },
+        {
+          "name": "-preprocess",
+          "alias": [
+            "-pp"
+          ],
+          "usage": [
+            "-pp, -preprocess [FILE]"
+          ],
+          "tip": [
+            "创建单个聚合的项目文件，其中包含生成期间可能使用的所有文件。"
+          ],
+          "next": []
+        },
+        {
+          "name": "-property",
+          "alias": [
+            "-p"
+          ],
+          "usage": [
+            "-p, -property <NAME>=<VALUE>"
+          ],
+          "tip": [
+            "设置或覆盖这些项目级属性。使用分号或逗号分隔多个属性。"
+          ],
+          "repeat": 99,
+          "next": []
+        },
+        {
+          "name": "-question",
+          "tip": [
+            "返回潜在问题的摘要并退出。"
+          ]
+        },
+        {
+          "name": "-restore",
+          "alias": [
+            "-r"
+          ],
+          "usage": [
+            "-r, -restore [TRUE|FALSE]"
+          ],
+          "tip": [
+            "在生成前运行目标以还原项目。"
+          ],
+          "next": [
+            {
+              "name": "False"
+            },
+            {
+              "name": "True"
+            }
+          ]
+        },
+        {
+          "name": "-target",
+          "alias": [
+            "-t"
+          ],
+          "usage": [
+            "-t, -target <TARGETS>"
+          ],
+          "tip": [
+            "在此项目中生成这些目标。使用分号或逗号分隔多个目标。"
+          ],
+          "next": []
+        },
+        {
+          "name": "-targets",
+          "alias": [
+            "-ts"
+          ],
+          "usage": [
+            "-ts, -targets [FILE]"
+          ],
+          "tip": [
+            "显示项目中的目标列表并退出。"
+          ],
+          "next": []
+        },
+        {
+          "name": "-toolsVersion",
+          "alias": [
+            "-tv"
+          ],
+          "usage": [
+            "-tv, -toolsVersion <VERSION>"
+          ],
+          "tip": [
+            "指定用于生成项目的工具集版本。"
+          ],
+          "next": []
+        },
+        {
+          "name": "-verbosity",
+          "alias": [
+            "-v"
+          ],
+          "usage": [
+            "-v, -verbosity <LEVEL>"
+          ],
+          "tip": [
+            "在事件日志中显示此数量的信息。可用的详细级别为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。"
+          ],
+          "next": [
+            {
+              "name": "detailed"
+            },
+            {
+              "name": "diagnostic"
+            },
+            {
+              "name": "minimal"
+            },
+            {
+              "name": "normal"
+            },
+            {
+              "name": "quiet"
+            }
+          ]
+        },
+        {
+          "name": "-version",
+          "alias": [
+            "-ver"
+          ],
+          "usage": [
+            "-ver, -version"
+          ],
+          "tip": [
+            "仅显示版本信息。"
+          ]
+        },
+        {
+          "name": "-warnAsError",
+          "usage": [
+            "-warnAsError [CODE[;CODE2]]"
+          ],
+          "tip": [
+            "将警告视为错误。可以选择提供要视为错误的特定警告代码或代码列表。"
+          ],
+          "next": []
+        },
+        {
+          "name": "-warnAsMessage",
+          "usage": [
+            "-warnAsMessage [CODE[;CODE2]]"
+          ],
+          "tip": [
+            "将警告视为消息。可以选择提供要视为消息的特定警告代码或代码列表。"
+          ],
+          "next": []
+        },
+        {
+          "name": "-warnNotAsError",
+          "usage": [
+            "-warnNotAsError [CODE[;CODE2]]"
+          ],
+          "tip": [
+            "将特定警告视为非错误，覆盖 -warnAsError。"
+          ],
+          "next": []
+        }
       ]
     },
     {
       "name": "new",
       "tip": [
-        "根据指定的模板初始化 C# 或 F# 项目。"
+        "创建新的 .NET 项目或文件。"
       ],
       "option": [
         {
           "name": "--dry-run",
           "tip": [
-            "显示如果运行该命令并创建模板时将会发生的情况摘要。"
+            "显示如果运行给定命令行并导致模板创建时将会发生的情况摘要。"
           ]
         },
         {
@@ -84,11 +1719,37 @@
             "-f"
           ],
           "usage": [
-            "-f, --framework"
+            "-f, --framework <FRAMEWORK>"
           ],
           "tip": [
             "指定目标框架。",
-            "示例：\"net6.0\"、\"net7.0-macos\"。"
+            "示例：\"net10.0\"、\"net9.0-macos\"。"
+          ],
+          "next": [
+            {
+              "name": "net10.0",
+              "tip": [
+                ".NET 10 "
+              ]
+            },
+            {
+              "name": "net8.0",
+              "tip": [
+                ".NET 8 "
+              ]
+            },
+            {
+              "name": "net9.0",
+              "tip": [
+                ".NET 9 "
+              ]
+            },
+            {
+              "name": "netstandard2.0",
+              "tip": [
+                ".NET Standard 2.0 "
+              ]
+            }
           ]
         },
         {
@@ -97,13 +1758,33 @@
             "-lang"
           ],
           "usage": [
-            "-lang, --language"
+            "-lang, --language <LANGUAGE>"
           ],
           "tip": [
             "要创建的模板语言。",
             "接受的语言因模板而异。",
             "对某些模板无效。",
             "支持的语言：[C#|F#|VB]"
+          ],
+          "next": [
+            {
+              "name": "C#",
+              "tip": [
+                "C# "
+              ]
+            },
+            {
+              "name": "F#",
+              "tip": [
+                "F# "
+              ]
+            },
+            {
+              "name": "VB",
+              "tip": [
+                "Visual Basic "
+              ]
+            }
           ]
         },
         {
@@ -112,11 +1793,17 @@
             "-n"
           ],
           "usage": [
-            "-n, --name"
+            "-n, --name <NAME>"
           ],
           "tip": [
-            "创建的输出名称。",
-            "如果未指定名称，则使用当前目录的名称。"
+            "要创建的输出的名称。如果未指定名称，则使用输出目录的名称。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--no-update-check",
+          "tip": [
+            "实例化模板时禁用对模板包更新的检查。"
           ]
         },
         {
@@ -125,62 +1812,670 @@
             "-o"
           ],
           "usage": [
-            "-o, --output"
+            "-o, --output <OUTPUT>"
           ],
           "tip": [
-            "放置生成的输出的位置。",
-            "默认为当前目录。"
-          ]
+            "放置生成的输出的位置。"
+          ],
+          "next": []
         },
         {
           "name": "--project",
+          "usage": [
+            "--project <PROJECT>"
+          ],
           "tip": [
-            "模板要添加到的项目。",
-            "如果未指定，将使用当前或父目录中的项目。"
-          ]
+            "用于上下文评估的项目。"
+          ],
+          "next": []
         },
         {
-          "name": "-no-update-check",
+          "name": "--verbosity",
+          "alias": [
+            "-v"
+          ],
+          "usage": [
+            "-v, --verbosity <LEVEL>"
+          ],
           "tip": [
-            "在实例化模板时禁用对模板包更新的检查。"
+            "设置详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal] 和 diag[nostic]。[默认值: normal]"
+          ],
+          "next": [
+            {
+              "name": "diagnostic"
+            },
+            {
+              "name": "minimal"
+            },
+            {
+              "name": "normal"
+            },
+            {
+              "name": "quiet"
+            }
           ]
         }
       ],
       "next": [
         {
-          "name": "details",
+          "name": "create",
+          "usage": [
+            "create <TEMPLATE_SHORT_NAME>"
+          ],
           "tip": [
-            "显示模板包的元数据。"
+            "使用给定的短名称实例化模板。是 'dotnet new <模板名称>' 的别名。"
+          ],
+          "option": [
+            {
+              "name": "--dry-run",
+              "tip": [
+                "显示如果运行给定命令行并导致模板创建时将会发生的情况摘要。"
+              ]
+            },
+            {
+              "name": "--force",
+              "tip": [
+                "强制生成内容，即使这会更改现有文件。"
+              ]
+            },
+            {
+              "name": "--name",
+              "alias": [
+                "-n"
+              ],
+              "usage": [
+                "-n, --name <NAME>"
+              ],
+              "tip": [
+                "要创建的输出的名称。如果未指定名称，则使用输出目录的名称。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--no-update-check",
+              "tip": [
+                "实例化模板时禁用对模板包更新的检查。"
+              ]
+            },
+            {
+              "name": "--output",
+              "alias": [
+                "-o"
+              ],
+              "usage": [
+                "-o, --output <OUTPUT>"
+              ],
+              "tip": [
+                "放置生成的输出的位置。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--project",
+              "usage": [
+                "--project <PROJECT>"
+              ],
+              "tip": [
+                "用于上下文评估的项目。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "设置详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal] 和 diag[nostic]。[默认值: normal]"
+              ],
+              "next": [
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "details",
+          "usage": [
+            "details <PACKAGE_IDENTIFIER>"
+          ],
+          "tip": [
+            "提供指定模板包的详细信息。",
+            "该命令会检查包是否在本地安装，如果未找到，则搜索配置的 NuGet 源。"
+          ],
+          "option": [
+            {
+              "name": "--interactive",
+              "tip": [
+                "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+              ]
+            },
+            {
+              "name": "--nuget-source",
+              "alias": [
+                "--add-source"
+              ],
+              "usage": [
+                "--add-source, --nuget-source <NUGET_SOURCE>"
+              ],
+              "tip": [
+                "指定要使用的 NuGet 源。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "设置详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal] 和 diag[nostic]。[默认值: normal]"
+              ],
+              "next": [
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
           ]
         },
         {
           "name": "install",
+          "usage": [
+            "install <PACKAGE>"
+          ],
           "tip": [
             "安装模板包。"
+          ],
+          "option": [
+            {
+              "name": "--force",
+              "tip": [
+                "即使会覆盖来自其他源的模板包，也允许从指定源安装模板包。"
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+              ]
+            },
+            {
+              "name": "--nuget-source",
+              "alias": [
+                "--add-source"
+              ],
+              "usage": [
+                "--add-source, --nuget-source <NUGET_SOURCE>"
+              ],
+              "tip": [
+                "指定要使用的 NuGet 源。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "设置详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal] 和 diag[nostic]。[默认值: normal]"
+              ],
+              "next": [
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
           ]
         },
         {
           "name": "list",
+          "usage": [
+            "list [<TEMPLATE_NAME>]"
+          ],
           "tip": [
-            "列出可使用 dotnet new 运行的可用模板。"
+            "列出包含指定模板名称的模板。如果未指定名称，则列出所有模板。"
+          ],
+          "option": [
+            {
+              "name": "--author",
+              "usage": [
+                "--author <AUTHOR>"
+              ],
+              "tip": [
+                "基于模板作者筛选模板。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--columns",
+              "usage": [
+                "--columns <AUTHOR|LANGUAGE|TAGS|TYPE>"
+              ],
+              "tip": [
+                "指定输出中要显示的列。"
+              ],
+              "next": [
+                {
+                  "name": "author"
+                },
+                {
+                  "name": "language"
+                },
+                {
+                  "name": "tags"
+                },
+                {
+                  "name": "type"
+                }
+              ]
+            },
+            {
+              "name": "--columns-all",
+              "tip": [
+                "在输出中显示所有列。"
+              ]
+            },
+            {
+              "name": "--ignore-constraints",
+              "tip": [
+                "禁用检查模板是否满足运行约束。"
+              ]
+            },
+            {
+              "name": "--language",
+              "alias": [
+                "-lang"
+              ],
+              "usage": [
+                "-lang, --language <LANGUAGE>"
+              ],
+              "tip": [
+                "基于语言筛选模板。"
+              ],
+              "next": [
+                {
+                  "name": "C#",
+                  "tip": [
+                    "C# "
+                  ]
+                },
+                {
+                  "name": "F#",
+                  "tip": [
+                    "F# "
+                  ]
+                },
+                {
+                  "name": "VB",
+                  "tip": [
+                    "Visual Basic "
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "--output",
+              "alias": [
+                "-o"
+              ],
+              "usage": [
+                "-o, --output <OUTPUT>"
+              ],
+              "tip": [
+                "放置生成的输出的位置。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--project",
+              "usage": [
+                "--project <PROJECT>"
+              ],
+              "tip": [
+                "用于上下文评估的项目。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--tag",
+              "usage": [
+                "--tag <TAG>"
+              ],
+              "tip": [
+                "基于标签筛选模板。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--type",
+              "usage": [
+                "--type <TYPE>"
+              ],
+              "tip": [
+                "基于可用类型筛选模板。预定义值为 \"project\" 和 \"item\"。"
+              ],
+              "next": [
+                {
+                  "name": "item"
+                },
+                {
+                  "name": "project"
+                }
+              ]
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "设置详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal] 和 diag[nostic]。[默认值: normal]"
+              ],
+              "next": [
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
           ]
         },
         {
           "name": "search",
+          "usage": [
+            "search [<TEMPLATE_NAME>]"
+          ],
           "tip": [
-            "在 NuGet.org 上搜索 dotnet new 支持的模板。"
+            "在 NuGet.org 上搜索模板。"
+          ],
+          "option": [
+            {
+              "name": "--author",
+              "usage": [
+                "--author <AUTHOR>"
+              ],
+              "tip": [
+                "基于模板作者筛选模板。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--columns",
+              "usage": [
+                "--columns <AUTHOR|LANGUAGE|TAGS|TYPE>"
+              ],
+              "tip": [
+                "指定输出中要显示的列。"
+              ],
+              "next": [
+                {
+                  "name": "author"
+                },
+                {
+                  "name": "language"
+                },
+                {
+                  "name": "tags"
+                },
+                {
+                  "name": "type"
+                }
+              ]
+            },
+            {
+              "name": "--columns-all",
+              "tip": [
+                "在输出中显示所有列。"
+              ]
+            },
+            {
+              "name": "--language",
+              "alias": [
+                "-lang"
+              ],
+              "usage": [
+                "-lang, --language <LANGUAGE>"
+              ],
+              "tip": [
+                "基于语言筛选模板。"
+              ],
+              "next": [
+                {
+                  "name": "C#",
+                  "tip": [
+                    "C# "
+                  ]
+                },
+                {
+                  "name": "F#",
+                  "tip": [
+                    "F# "
+                  ]
+                },
+                {
+                  "name": "VB",
+                  "tip": [
+                    "Visual Basic "
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "--package",
+              "usage": [
+                "--package <PACKAGE>"
+              ],
+              "tip": [
+                "基于 NuGet 包 ID 筛选模板。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--tag",
+              "usage": [
+                "--tag <TAG>"
+              ],
+              "tip": [
+                "基于标签筛选模板。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--type",
+              "usage": [
+                "--type <TYPE>"
+              ],
+              "tip": [
+                "基于可用类型筛选模板。预定义值为 \"project\" 和 \"item\"。"
+              ],
+              "next": [
+                {
+                  "name": "item"
+                },
+                {
+                  "name": "project"
+                }
+              ]
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "设置详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal] 和 diag[nostic]。[默认值: normal]"
+              ],
+              "next": [
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
           ]
         },
         {
           "name": "uninstall",
+          "usage": [
+            "uninstall [<PACKAGE>]"
+          ],
           "tip": [
             "卸载模板包。"
+          ],
+          "option": [
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "设置详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal] 和 diag[nostic]。[默认值: normal]"
+              ],
+              "next": [
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
           ]
         },
         {
           "name": "update",
           "tip": [
-            "更新已安装的模板包。"
+            "检查当前安装的模板包是否有更新，并安装更新。"
+          ],
+          "option": [
+            {
+              "name": "--check-only",
+              "alias": [
+                "--dry-run"
+              ],
+              "usage": [
+                "--dry-run, --check-only"
+              ],
+              "tip": [
+                "仅检查更新并显示要更新的模板包，而不应用更新。"
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+              ]
+            },
+            {
+              "name": "--nuget-source",
+              "alias": [
+                "--add-source"
+              ],
+              "usage": [
+                "--add-source, --nuget-source <NUGET_SOURCE>"
+              ],
+              "tip": [
+                "指定要使用的 NuGet 源。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "设置详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal] 和 diag[nostic]。[默认值: normal]"
+              ],
+              "next": [
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
           ]
         }
       ]
@@ -188,61 +2483,1058 @@
     {
       "name": "nuget",
       "tip": [
-        "用于管理 NuGet 包管理器的 .NET 命令。"
+        "提供其他 NuGet 命令。"
       ],
       "next": [
         {
           "name": "add",
+          "usage": [
+            "add [command]"
+          ],
           "tip": [
             "添加 NuGet 源。"
+          ],
+          "option": [
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "强制应用程序使用固定不变、基于英语的区域性运行。"
+              ]
+            }
+          ],
+          "next": [
+            {
+              "name": "client-cert",
+              "tip": [
+                "添加与给定包源名称匹配的客户端证书配置。"
+              ]
+            },
+            {
+              "name": "source",
+              "usage": [
+                "source <PACKAGE_SOURCE_PATH>"
+              ],
+              "tip": [
+                "添加 NuGet 源。"
+              ],
+              "option": [
+                {
+                  "name": "--allow-insecure-connections",
+                  "tip": [
+                    "允许添加或更新包时使用 HTTP 连接。注意：此方法不安全。"
+                  ]
+                },
+                {
+                  "name": "--configfile",
+                  "usage": [
+                    "--configfile <CONFIGFILE>"
+                  ],
+                  "tip": [
+                    "NuGet 配置文件。如果指定，将只使用此文件中的设置。"
+                  ],
+                  "next": []
+                },
+                {
+                  "name": "--name",
+                  "alias": [
+                    "-n"
+                  ],
+                  "usage": [
+                    "-n, --name <NAME>"
+                  ],
+                  "tip": [
+                    "源的名称。"
+                  ],
+                  "next": []
+                },
+                {
+                  "name": "--password",
+                  "alias": [
+                    "-p"
+                  ],
+                  "usage": [
+                    "-p, --password <PASSWORD>"
+                  ],
+                  "tip": [
+                    "连接到经过身份验证的源时要使用的密码。"
+                  ],
+                  "next": []
+                },
+                {
+                  "name": "--protocol-version",
+                  "usage": [
+                    "--protocol-version <VERSION>"
+                  ],
+                  "tip": [
+                    "要使用的 NuGet 服务器协议版本。当前支持的版本为 2 和 3。如果未指定，默认为 2。"
+                  ],
+                  "next": [
+                    {
+                      "name": "2",
+                      "tip": [
+                        "NuGet v2 协议"
+                      ]
+                    },
+                    {
+                      "name": "3",
+                      "tip": [
+                        "NuGet v3 协议"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "--store-password-in-clear-text",
+                  "tip": [
+                    "通过禁用密码加密来启用存储可移植的包源凭据。"
+                  ]
+                },
+                {
+                  "name": "--username",
+                  "alias": [
+                    "-u"
+                  ],
+                  "usage": [
+                    "-u, --username <USERNAME>"
+                  ],
+                  "tip": [
+                    "连接到经过身份验证的源时要使用的用户名。"
+                  ],
+                  "next": []
+                },
+                {
+                  "name": "--valid-authentication-types",
+                  "usage": [
+                    "--valid-authentication-types <TYPES>"
+                  ],
+                  "tip": [
+                    "此源的有效身份验证类型列表，以逗号分隔。如果服务器通告 NTLM 或 Negotiate 并且必须使用 Basic 机制发送凭据（例如对本地 Azure DevOps Server 使用 PAT），则将其设置为 basic。"
+                  ],
+                  "next": [
+                    {
+                      "name": "basic",
+                      "tip": [
+                        "Basic 身份验证"
+                      ]
+                    },
+                    {
+                      "name": "digest",
+                      "tip": [
+                        "Digest 身份验证"
+                      ]
+                    },
+                    {
+                      "name": "kerberos",
+                      "tip": [
+                        "Kerberos 身份验证"
+                      ]
+                    },
+                    {
+                      "name": "negotiate",
+                      "tip": [
+                        "Negotiate 身份验证"
+                      ]
+                    },
+                    {
+                      "name": "ntlm",
+                      "tip": [
+                        "NTLM 身份验证"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "config",
+          "usage": [
+            "config [command]"
+          ],
+          "tip": [
+            "NuGet 配置 CLI。"
+          ],
+          "option": [
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "强制应用程序使用固定不变、基于英语的区域性运行。"
+              ]
+            }
+          ],
+          "next": [
+            {
+              "name": "get",
+              "usage": [
+                "get <ALL_OR_CONFIG_KEY>"
+              ],
+              "tip": [
+                "获取将要应用的 NuGet 配置设置。"
+              ]
+            },
+            {
+              "name": "paths",
+              "tip": [
+                "列出在特定目录中调用 NuGet 命令时将应用的所有 NuGet 配置文件的路径。"
+              ]
+            },
+            {
+              "name": "set",
+              "usage": [
+                "set <CONFIG_KEY> <CONFIG_VALUE>"
+              ],
+              "tip": [
+                "设置指定 NuGet 配置设置的值。"
+              ]
+            },
+            {
+              "name": "unset",
+              "usage": [
+                "unset <CONFIG_KEY>"
+              ],
+              "tip": [
+                "从指定的 NuGet 配置设置中移除键值对。"
+              ]
+            }
           ]
         },
         {
           "name": "delete",
+          "usage": [
+            "delete <PACKAGE_ID> <PACKAGE_VERSION>"
+          ],
           "tip": [
-            "从服务器删除或撤销包的发布。"
+            "从服务器删除包。"
+          ],
+          "option": [
+            {
+              "name": "--api-key",
+              "alias": [
+                "-k"
+              ],
+              "usage": [
+                "-k, --api-key <API_KEY>"
+              ],
+              "tip": [
+                "服务器的 API 密钥。如果未设置，则读取 NUGET_API_KEY 环境变量。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "强制应用程序使用固定不变、基于英语的区域性运行。"
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "允许命令阻塞并要求针对身份验证等操作执行手动操作。"
+              ]
+            },
+            {
+              "name": "--no-service-endpoint",
+              "tip": [
+                "不向源 URL 追加 \"api/v2/package\"。"
+              ]
+            },
+            {
+              "name": "--non-interactive",
+              "tip": [
+                "不提示用户输入或确认。"
+              ]
+            },
+            {
+              "name": "--source",
+              "alias": [
+                "-s"
+              ],
+              "usage": [
+                "-s, --source <SOURCE>"
+              ],
+              "tip": [
+                "要使用的包源（URL、UNC/文件夹路径或包源名称）。如果在 NuGet.Config 中指定，则默认为 DefaultPushSource。"
+              ],
+              "next": []
+            }
           ]
         },
         {
           "name": "disable",
+          "usage": [
+            "disable [command]"
+          ],
           "tip": [
             "禁用 NuGet 源。"
+          ],
+          "option": [
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "强制应用程序使用固定不变、基于英语的区域性运行。"
+              ]
+            }
+          ],
+          "next": [
+            {
+              "name": "source",
+              "usage": [
+                "source <NAME>"
+              ],
+              "tip": [
+                "禁用 NuGet 源。"
+              ]
+            }
           ]
         },
         {
           "name": "enable",
+          "usage": [
+            "enable [command]"
+          ],
           "tip": [
             "启用 NuGet 源。"
+          ],
+          "option": [
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "强制应用程序使用固定不变、基于英语的区域性运行。"
+              ]
+            }
+          ],
+          "next": [
+            {
+              "name": "source",
+              "usage": [
+                "source <NAME>"
+              ],
+              "tip": [
+                "启用 NuGet 源。"
+              ]
+            }
           ]
         },
         {
           "name": "list",
+          "usage": [
+            "list [command]"
+          ],
           "tip": [
-            "列出所有配置的 NuGet 源。"
+            "列出配置的 NuGet 源。"
+          ],
+          "option": [
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "强制应用程序使用固定不变、基于英语的区域性运行。"
+              ]
+            }
+          ],
+          "next": [
+            {
+              "name": "client-cert",
+              "tip": [
+                "列出配置中的所有客户端证书。"
+              ]
+            },
+            {
+              "name": "source",
+              "tip": [
+                "列出所有配置的 NuGet 源。"
+              ]
+            }
           ]
         },
         {
           "name": "locals",
+          "usage": [
+            "locals [<CACHE_LOCATION(S)>]"
+          ],
           "tip": [
-            "清除或列出本地 NuGet 资源，例如 http 请求缓存、临时缓存或机范围内的全局包文件夹。"
+            "清除或列出本地 NuGet 资源，例如 http 请求缓存、包文件夹、插件操作缓存或机范围内的全局包文件夹。"
+          ],
+          "option": [
+            {
+              "name": "--clear",
+              "alias": [
+                "-c"
+              ],
+              "usage": [
+                "-c, --clear"
+              ],
+              "tip": [
+                "清除选定的本地资源或缓存位置。"
+              ]
+            },
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "强制应用程序使用固定不变、基于英语的区域性运行。"
+              ]
+            },
+            {
+              "name": "--list",
+              "alias": [
+                "-l"
+              ],
+              "usage": [
+                "-l, --list"
+              ],
+              "tip": [
+                "列出选定的本地资源或缓存位置。"
+              ]
+            }
+          ],
+          "next": [
+            {
+              "name": "all",
+              "tip": [
+                "所有本地 NuGet 资源。"
+              ]
+            },
+            {
+              "name": "global-packages",
+              "tip": [
+                "机范围内的全局包文件夹。"
+              ]
+            },
+            {
+              "name": "http-cache",
+              "tip": [
+                "HTTP 缓存。"
+              ]
+            },
+            {
+              "name": "temp",
+              "tip": [
+                "临时缓存。"
+              ]
+            }
           ]
         },
         {
           "name": "push",
+          "usage": [
+            "push <PACKAGE_PATHS>"
+          ],
           "tip": [
             "将包推送至服务器并发布。"
+          ],
+          "option": [
+            {
+              "name": "--allow-insecure-connections",
+              "tip": [
+                "允许推送到 HTTP 源（不安全）。"
+              ]
+            },
+            {
+              "name": "--api-key",
+              "alias": [
+                "-k"
+              ],
+              "usage": [
+                "-k, --api-key <API_KEY>"
+              ],
+              "tip": [
+                "服务器的 API 密钥。如果未设置，则读取 NUGET_API_KEY 环境变量。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--configfile",
+              "usage": [
+                "--configfile <CONFIGFILE>"
+              ],
+              "tip": [
+                "NuGet 配置文件。如果指定，将只使用此文件中的设置。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--disable-buffering",
+              "alias": [
+                "-d"
+              ],
+              "usage": [
+                "-d, --disable-buffering"
+              ],
+              "tip": [
+                "推送到 HTTP(S) 服务器时禁用缓冲以减少内存使用。"
+              ]
+            },
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "强制应用程序使用固定不变、基于英语的区域性运行。"
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "允许命令阻塞并要求针对身份验证等操作执行手动操作。"
+              ]
+            },
+            {
+              "name": "--no-service-endpoint",
+              "tip": [
+                "不向源 URL 追加 \"api/v2/package\"。"
+              ]
+            },
+            {
+              "name": "--no-symbols",
+              "alias": [
+                "-n"
+              ],
+              "usage": [
+                "-n, --no-symbols"
+              ],
+              "tip": [
+                "如果存在符号包，则不会将其推送到符号服务器。"
+              ]
+            },
+            {
+              "name": "--skip-duplicate",
+              "tip": [
+                "如果包和版本已存在，则跳过它并继续推送下一个包（如果有）。"
+              ]
+            },
+            {
+              "name": "--source",
+              "alias": [
+                "-s"
+              ],
+              "usage": [
+                "-s, --source <SOURCE>"
+              ],
+              "tip": [
+                "要使用的包源（URL、UNC/文件夹路径或包源名称）。如果在 NuGet.Config 中指定，则默认为 DefaultPushSource。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--symbol-api-key",
+              "alias": [
+                "-sk"
+              ],
+              "usage": [
+                "-sk, --symbol-api-key <SYMBOL_API_KEY>"
+              ],
+              "tip": [
+                "符号服务器的 API 密钥。如果未设置，则读取 NUGET_SYMBOL_API_KEY 环境变量。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--symbol-source",
+              "alias": [
+                "-ss"
+              ],
+              "usage": [
+                "-ss, --symbol-source <SYMBOL_SOURCE>"
+              ],
+              "tip": [
+                "要使用的符号服务器 URL。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--timeout",
+              "alias": [
+                "-t"
+              ],
+              "usage": [
+                "-t, --timeout <TIMEOUT>"
+              ],
+              "tip": [
+                "推送到服务器的超时时间（秒）。默认值为 300 秒（5 分钟）。"
+              ],
+              "next": []
+            }
           ]
         },
         {
           "name": "remove",
+          "usage": [
+            "remove [command]"
+          ],
           "tip": [
             "移除 NuGet 源。"
+          ],
+          "option": [
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "强制应用程序使用固定不变、基于英语的区域性运行。"
+              ]
+            }
+          ],
+          "next": [
+            {
+              "name": "client-cert",
+              "tip": [
+                "移除与给定包源名称匹配的客户端证书配置。"
+              ]
+            },
+            {
+              "name": "source",
+              "usage": [
+                "source <NAME>"
+              ],
+              "tip": [
+                "移除 NuGet 源。"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "sign",
+          "usage": [
+            "sign <PACKAGE_PATHS>"
+          ],
+          "tip": [
+            "使用指定的证书对 <package-paths> 处的 NuGet 包进行签名。"
+          ],
+          "option": [
+            {
+              "name": "--allow-untrusted-root",
+              "tip": [
+                "允许使用根证书不在受信任根存储中的证书进行签名。"
+              ]
+            },
+            {
+              "name": "--certificate-fingerprint",
+              "usage": [
+                "--certificate-fingerprint <FINGERPRINT>"
+              ],
+              "tip": [
+                "用于在本地证书存储中搜索证书的证书的 SHA-256、SHA-384 或 SHA-512 指纹。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--certificate-password",
+              "usage": [
+                "--certificate-password <PASSWORD>"
+              ],
+              "tip": [
+                "证书的密码（如果需要）。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--certificate-path",
+              "usage": [
+                "--certificate-path <PATH>"
+              ],
+              "tip": [
+                "对包进行签名时要使用的证书的文件路径。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--certificate-store-location",
+              "usage": [
+                "--certificate-store-location <LOCATION>"
+              ],
+              "tip": [
+                "用于搜索证书的 X.509 证书存储的名称。默认为 \"CurrentUser\"。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--certificate-store-name",
+              "usage": [
+                "--certificate-store-name <NAME>"
+              ],
+              "tip": [
+                "用于搜索证书的 X.509 证书存储的名称。默认为 \"My\"。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--certificate-subject-name",
+              "usage": [
+                "--certificate-subject-name <NAME>"
+              ],
+              "tip": [
+                "用于在本地证书存储中搜索证书的证书主题名称。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "强制应用程序使用固定不变、基于英语的区域性运行。"
+              ]
+            },
+            {
+              "name": "--hash-algorithm",
+              "usage": [
+                "--hash-algorithm <ALGORITHM>"
+              ],
+              "tip": [
+                "用于对包进行签名的哈希算法。默认为 SHA256。"
+              ],
+              "next": [
+                {
+                  "name": "SHA256",
+                  "tip": [
+                    "SHA-256 "
+                  ]
+                },
+                {
+                  "name": "SHA384",
+                  "tip": [
+                    "SHA-384 "
+                  ]
+                },
+                {
+                  "name": "SHA512",
+                  "tip": [
+                    "SHA-512 "
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "--output",
+              "alias": [
+                "-o"
+              ],
+              "usage": [
+                "-o, --output <OUTPUT>"
+              ],
+              "tip": [
+                "已签名包应保存到的目录。默认情况下，原始包会被已签名包覆盖。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--overwrite",
+              "tip": [
+                "指示是否应覆盖当前签名的开关。默认情况下，如果包已有签名，命令将失败。"
+              ]
+            },
+            {
+              "name": "--timestamp-hash-algorithm",
+              "usage": [
+                "--timestamp-hash-algorithm <ALGORITHM>"
+              ],
+              "tip": [
+                "RFC 3161 时间戳服务器使用的哈希算法。默认为 SHA256。"
+              ],
+              "next": [
+                {
+                  "name": "SHA256",
+                  "tip": [
+                    "SHA-256 "
+                  ]
+                },
+                {
+                  "name": "SHA384",
+                  "tip": [
+                    "SHA-384 "
+                  ]
+                },
+                {
+                  "name": "SHA512",
+                  "tip": [
+                    "SHA-512 "
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "--timestamper",
+              "usage": [
+                "--timestamper <URL>"
+              ],
+              "tip": [
+                "RFC 3161 时间戳服务器的 URL。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "设置命令的详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。"
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "trust",
+          "usage": [
+            "trust [command]"
+          ],
+          "tip": [
+            "管理受信任的签名者。"
+          ],
+          "option": [
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "强制应用程序使用固定不变、基于英语的区域性运行。"
+              ]
+            }
+          ],
+          "next": [
+            {
+              "name": "author",
+              "usage": [
+                "author <NAME> <PACKAGE>"
+              ],
+              "tip": [
+                "基于包作者签名添加具有给定名称的受信任签名者。"
+              ]
+            },
+            {
+              "name": "certificate",
+              "usage": [
+                "certificate <NAME> <FINGERPRINT>"
+              ],
+              "tip": [
+                "基于签名包的存储库签名或副签名添加具有给定名称的受信任签名者。"
+              ]
+            },
+            {
+              "name": "list",
+              "tip": [
+                "列出配置中的所有受信任签名者。"
+              ]
+            },
+            {
+              "name": "remove",
+              "usage": [
+                "remove <NAME>"
+              ],
+              "tip": [
+                "移除与给定名称匹配的任何受信任签名者。"
+              ]
+            },
+            {
+              "name": "repository",
+              "usage": [
+                "repository <NAME> <PACKAGE>"
+              ],
+              "tip": [
+                "基于签名包的存储库签名或副签名添加具有给定名称的受信任签名者。"
+              ]
+            },
+            {
+              "name": "source",
+              "usage": [
+                "source <NAME>"
+              ],
+              "tip": [
+                "基于给定的包源添加受信任签名者。"
+              ],
+              "option": [
+                {
+                  "name": "--owners",
+                  "usage": [
+                    "--owners <OWNERS>"
+                  ],
+                  "tip": [
+                    "以分号分隔的受信任所有者列表，用于进一步限制存储库的信任。"
+                  ],
+                  "next": []
+                },
+                {
+                  "name": "--source-url",
+                  "usage": [
+                    "--source-url <URL>"
+                  ],
+                  "tip": [
+                    "如果提供了 source-url，则它必须是 v3 包源 URL（如 https://api.nuget.org/v3/index.json）。不支持其他包源类型。"
+                  ],
+                  "next": []
+                }
+              ]
+            },
+            {
+              "name": "sync",
+              "usage": [
+                "sync <NAME>"
+              ],
+              "tip": [
+                "删除当前证书列表，并用存储库中的最新列表替换它们。"
+              ]
+            }
           ]
         },
         {
           "name": "update",
+          "usage": [
+            "update [command]"
+          ],
           "tip": [
             "更新 NuGet 源。"
+          ],
+          "option": [
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "强制应用程序使用固定不变、基于英语的区域性运行。"
+              ]
+            }
+          ],
+          "next": [
+            {
+              "name": "client-cert",
+              "tip": [
+                "更新与给定包源名称匹配的客户端证书配置。"
+              ]
+            },
+            {
+              "name": "source",
+              "usage": [
+                "source <NAME>"
+              ],
+              "tip": [
+                "更新 NuGet 源。"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "verify",
+          "usage": [
+            "verify <PACKAGE_PATHS>"
+          ],
+          "tip": [
+            "验证已签名的 NuGet 包。"
+          ],
+          "option": [
+            {
+              "name": "--all",
+              "tip": [
+                "指定应对包执行所有可能的验证。"
+              ]
+            },
+            {
+              "name": "--certificate-fingerprint",
+              "usage": [
+                "--certificate-fingerprint <FINGERPRINT>"
+              ],
+              "tip": [
+                "验证签名者证书是否与指定的某个 SHA256 指纹匹配。多个输入应以空格分隔。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--configfile",
+              "usage": [
+                "--configfile <CONFIGFILE>"
+              ],
+              "tip": [
+                "NuGet 配置文件。如果指定，将只使用此文件中的设置。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--force-english-output",
+              "tip": [
+                "强制应用程序使用固定不变、基于英语的区域性运行。"
+              ]
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "设置命令的详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。"
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "why",
+          "usage": [
+            "why <PROJECT | SOLUTION | FILE> <PACKAGE>"
+          ],
+          "tip": [
+            "显示给定项目或解决方案中特定包的依赖项关系图。"
+          ],
+          "option": [
+            {
+              "name": "--framework",
+              "alias": [
+                "-f"
+              ],
+              "usage": [
+                "-f, --framework <FRAMEWORK>"
+              ],
+              "tip": [
+                "为其显示依赖项关系图的目标框架。"
+              ],
+              "next": [
+                {
+                  "name": "net10.0",
+                  "tip": [
+                    ".NET 10 "
+                  ]
+                },
+                {
+                  "name": "net8.0",
+                  "tip": [
+                    ".NET 8 "
+                  ]
+                },
+                {
+                  "name": "net9.0",
+                  "tip": [
+                    ".NET 9 "
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
@@ -250,37 +3542,835 @@
     {
       "name": "pack",
       "tip": [
-        "为代码创建 NuGet 包。"
+        "创建 NuGet 包。"
+      ],
+      "option": [
+        {
+          "name": "--artifacts-path",
+          "usage": [
+            "--artifacts-path <ARTIFACTS_DIR>"
+          ],
+          "tip": [
+            "产物路径。项目的所有输出（包括生成、发布和打包输出）都将放到指定路径下的子文件夹中。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--configuration",
+          "alias": [
+            "-c"
+          ],
+          "usage": [
+            "-c, --configuration <CONFIGURATION>"
+          ],
+          "tip": [
+            "用于生成包的配置。默认值为 'Release'。"
+          ],
+          "next": [
+            {
+              "name": "Debug"
+            },
+            {
+              "name": "Release"
+            }
+          ]
+        },
+        {
+          "name": "--disable-build-servers",
+          "tip": [
+            "强制命令忽略任何永久性生成服务器。"
+          ]
+        },
+        {
+          "name": "--include-source",
+          "tip": [
+            "包含 PDB 和源文件。源文件放入生成的 nuget 包中的 'src' 文件夹。"
+          ]
+        },
+        {
+          "name": "--include-symbols",
+          "tip": [
+            "在输出目录中包含带符号的包以及常规包。"
+          ]
+        },
+        {
+          "name": "--interactive",
+          "tip": [
+            "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+          ]
+        },
+        {
+          "name": "--no-build",
+          "tip": [
+            "打包前不生成项目。隐含 --no-restore。"
+          ]
+        },
+        {
+          "name": "--no-logo",
+          "alias": [
+            "-nologo"
+          ],
+          "usage": [
+            "-nologo, --no-logo"
+          ],
+          "tip": [
+            "不显示启动横幅或版权消息。"
+          ]
+        },
+        {
+          "name": "--no-restore",
+          "tip": [
+            "生成前不还原项目。"
+          ]
+        },
+        {
+          "name": "--output",
+          "alias": [
+            "-o"
+          ],
+          "usage": [
+            "-o, --output <OUTPUT_DIR>"
+          ],
+          "tip": [
+            "放置生成的包的输出目录。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--runtime",
+          "alias": [
+            "-r"
+          ],
+          "usage": [
+            "-r, --runtime <RUNTIME_IDENTIFIER>"
+          ],
+          "tip": [
+            "要为其生成的目标运行时。"
+          ],
+          "next": [
+            {
+              "name": "linux-x64",
+              "tip": [
+                "Linux x64 "
+              ]
+            },
+            {
+              "name": "osx-arm64",
+              "tip": [
+                "macOS ARM64 "
+              ]
+            },
+            {
+              "name": "win-x64",
+              "tip": [
+                "Windows x64 "
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--serviceable",
+          "alias": [
+            "-s"
+          ],
+          "usage": [
+            "-s, --serviceable"
+          ],
+          "tip": [
+            "在包中设置 serviceable 标志。"
+          ]
+        },
+        {
+          "name": "--use-current-runtime",
+          "alias": [
+            "--ucr"
+          ],
+          "usage": [
+            "--ucr, --use-current-runtime"
+          ],
+          "tip": [
+            "使用当前运行时作为目标运行时。"
+          ]
+        },
+        {
+          "name": "--verbosity",
+          "alias": [
+            "-verbosity",
+            "-v"
+          ],
+          "usage": [
+            "-v, -verbosity, --verbosity <LEVEL>"
+          ],
+          "tip": [
+            "设置 MSBuild 详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。"
+          ],
+          "next": [
+            {
+              "name": "detailed"
+            },
+            {
+              "name": "diagnostic"
+            },
+            {
+              "name": "minimal"
+            },
+            {
+              "name": "normal"
+            },
+            {
+              "name": "quiet"
+            }
+          ]
+        },
+        {
+          "name": "--version",
+          "usage": [
+            "--version <VERSION>"
+          ],
+          "tip": [
+            "要创建的包的版本。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--version-suffix",
+          "usage": [
+            "--version-suffix <VERSION_SUFFIX>"
+          ],
+          "tip": [
+            "设置生成项目时使用的 $(VersionSuffix) 属性的值。"
+          ],
+          "next": []
+        }
       ]
     },
     {
       "name": "package",
       "tip": [
-        "用于管理 NuGet 包的 .NET 命令。"
+        "搜索、添加、移除或列出 .NET 项目的 PackageReferences。"
       ],
       "next": [
         {
           "name": "add",
+          "usage": [
+            "add <PACKAGE_ID>"
+          ],
           "tip": [
-            "添加 NuGet 包。"
+            "向项目添加 NuGet 包引用。"
+          ],
+          "option": [
+            {
+              "name": "--file",
+              "usage": [
+                "--file <FILE>"
+              ],
+              "tip": [
+                "要操作的文件型应用。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--framework",
+              "alias": [
+                "-f"
+              ],
+              "usage": [
+                "-f, --framework <FRAMEWORK>"
+              ],
+              "tip": [
+                "仅在面向特定框架时添加引用。"
+              ],
+              "next": [
+                {
+                  "name": "net10.0",
+                  "tip": [
+                    ".NET 10 "
+                  ]
+                },
+                {
+                  "name": "net8.0",
+                  "tip": [
+                    ".NET 8 "
+                  ]
+                },
+                {
+                  "name": "net9.0",
+                  "tip": [
+                    ".NET 9 "
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+              ]
+            },
+            {
+              "name": "--no-restore",
+              "alias": [
+                "-n"
+              ],
+              "usage": [
+                "-n, --no-restore"
+              ],
+              "tip": [
+                "在不执行还原预览和兼容性检查的情况下添加引用。"
+              ]
+            },
+            {
+              "name": "--package-directory",
+              "usage": [
+                "--package-directory <PACKAGE_DIR>"
+              ],
+              "tip": [
+                "要将包还原到的目录。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--prerelease",
+              "tip": [
+                "允许安装预发布包。"
+              ]
+            },
+            {
+              "name": "--project",
+              "usage": [
+                "--project <PROJECT>"
+              ],
+              "tip": [
+                "要操作的项目文件。如果未指定文件，命令将在当前目录中搜索一个。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--source",
+              "alias": [
+                "-s"
+              ],
+              "usage": [
+                "-s, --source <SOURCE>"
+              ],
+              "tip": [
+                "还原期间使用的 NuGet 包源。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--version",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --version <VERSION>"
+              ],
+              "tip": [
+                "要添加的包的版本。"
+              ],
+              "next": []
+            }
+          ]
+        },
+        {
+          "name": "download",
+          "usage": [
+            "download <PACKAGES>"
+          ],
+          "tip": [
+            "将 NuGet 包下载到本地文件夹，而不需要项目文件。"
+          ],
+          "option": [
+            {
+              "name": "--allow-insecure-connections",
+              "tip": [
+                "允许从 HTTP（非 HTTPS）包源下载。"
+              ]
+            },
+            {
+              "name": "--configfile",
+              "usage": [
+                "--configfile <CONFIGFILE>"
+              ],
+              "tip": [
+                "NuGet 配置文件。如果指定，将只使用此文件中的设置。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+              ]
+            },
+            {
+              "name": "--output",
+              "alias": [
+                "-o"
+              ],
+              "usage": [
+                "-o, --output <OUTPUT>"
+              ],
+              "tip": [
+                "放置包的目录。默认为当前工作目录。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--prerelease",
+              "tip": [
+                "允许安装预发布包。"
+              ]
+            },
+            {
+              "name": "--source",
+              "alias": [
+                "-s"
+              ],
+              "usage": [
+                "-s, --source <SOURCE>"
+              ],
+              "tip": [
+                "指定要使用的一个或多个 NuGet 包源。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "设置命令的详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。"
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
           ]
         },
         {
           "name": "list",
           "tip": [
-            "列出 NuGet 包。"
+            "列出项目或解决方案的所有包引用。"
+          ],
+          "option": [
+            {
+              "name": "--configfile",
+              "alias": [
+                "--config"
+              ],
+              "usage": [
+                "--config, --configfile <CONFIG_FILE>"
+              ],
+              "tip": [
+                "要使用的 NuGet 配置文件的路径。需要 '--outdated'、'--deprecated' 或 '--vulnerable' 选项。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--deprecated",
+              "tip": [
+                "列出已弃用的包。不能与 '--vulnerable' 或 '--outdated' 选项结合使用。"
+              ]
+            },
+            {
+              "name": "--file",
+              "usage": [
+                "--file <FILE>"
+              ],
+              "tip": [
+                "要操作的文件型应用。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--format",
+              "usage": [
+                "--format <CONSOLE|JSON>"
+              ],
+              "tip": [
+                "指定 list packages 命令的输出格式类型。"
+              ],
+              "next": [
+                {
+                  "name": "console"
+                },
+                {
+                  "name": "json"
+                }
+              ]
+            },
+            {
+              "name": "--framework",
+              "alias": [
+                "-f"
+              ],
+              "usage": [
+                "-f, --framework <FRAMEWORK | FRAMEWORK\\RID>"
+              ],
+              "tip": [
+                "选择要显示其包的框架。多次使用该选项以指定多个框架。"
+              ],
+              "repeat": 99,
+              "next": [
+                {
+                  "name": "net10.0",
+                  "tip": [
+                    ".NET 10 "
+                  ]
+                },
+                {
+                  "name": "net8.0",
+                  "tip": [
+                    ".NET 8 "
+                  ]
+                },
+                {
+                  "name": "net9.0",
+                  "tip": [
+                    ".NET 9 "
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "--highest-minor",
+              "tip": [
+                "搜索较新包时仅考虑主版本号匹配的包。需要 '--outdated' 选项。"
+              ]
+            },
+            {
+              "name": "--highest-patch",
+              "tip": [
+                "搜索较新包时仅考虑主版本号和次版本号匹配的包。需要 '--outdated' 选项。"
+              ]
+            },
+            {
+              "name": "--include-prerelease",
+              "tip": [
+                "搜索较新包时考虑具有预发布版本的包。需要 '--outdated' 选项。"
+              ]
+            },
+            {
+              "name": "--include-transitive",
+              "tip": [
+                "列出传递依赖包和顶级包。"
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+              ]
+            },
+            {
+              "name": "--no-restore",
+              "tip": [
+                "运行命令前不执行还原。"
+              ]
+            },
+            {
+              "name": "--outdated",
+              "tip": [
+                "列出有较新版本的包。不能与 '--deprecated' 或 '--vulnerable' 选项结合使用。"
+              ]
+            },
+            {
+              "name": "--output-version",
+              "usage": [
+                "--output-version <OUTPUT_VERSION>"
+              ],
+              "tip": [
+                "指定机器可读输出的版本。需要 '--format json' 选项。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--project",
+              "usage": [
+                "--project <PROJECT>"
+              ],
+              "tip": [
+                "要操作的项目文件。如果未指定文件，命令将在当前目录中搜索一个。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--source",
+              "alias": [
+                "-s"
+              ],
+              "usage": [
+                "-s, --source <SOURCE>"
+              ],
+              "tip": [
+                "搜索较新包时使用的 NuGet 源。需要 '--outdated'、'--deprecated' 或 '--vulnerable' 选项。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "设置 MSBuild 详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。"
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            },
+            {
+              "name": "--vulnerable",
+              "tip": [
+                "列出具有已知漏洞的包。不能与 '--deprecated' 或 '--outdated' 选项结合使用。"
+              ]
+            }
           ]
         },
         {
           "name": "remove",
+          "usage": [
+            "remove <PACKAGE_NAME>"
+          ],
           "tip": [
-            "移除 NuGet 包。"
+            "从项目移除 NuGet 包引用。"
+          ],
+          "option": [
+            {
+              "name": "--file",
+              "usage": [
+                "--file <FILE>"
+              ],
+              "tip": [
+                "要操作的文件型应用。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+              ]
+            },
+            {
+              "name": "--project",
+              "usage": [
+                "--project <PROJECT>"
+              ],
+              "tip": [
+                "要操作的项目文件。如果未指定文件，命令将在当前目录中搜索一个。"
+              ],
+              "next": []
+            }
           ]
         },
         {
           "name": "search",
+          "usage": [
+            "search [<SEARCH_TERM>]"
+          ],
           "tip": [
-            "搜索 NuGet 包。"
+            "在一个或多个包源中搜索与搜索词匹配的包。如果未指定源，则使用 NuGet.Config 中定义的所有源。"
+          ],
+          "option": [
+            {
+              "name": "--configfile",
+              "usage": [
+                "--configfile <CONFIG_FILE>"
+              ],
+              "tip": [
+                "NuGet 配置文件。如果指定，将只使用此文件中的设置。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--exact-match",
+              "tip": [
+                "要求搜索词与包名称完全匹配。会导致 `--take` 和 `--skip` 选项被忽略。"
+              ]
+            },
+            {
+              "name": "--format",
+              "usage": [
+                "--format <TABLE|JSON>"
+              ],
+              "tip": [
+                "相应地设置输出格式。可以是 `table` 或 `json`。默认值为 `table`。"
+              ],
+              "next": [
+                {
+                  "name": "json"
+                },
+                {
+                  "name": "table"
+                }
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+              ]
+            },
+            {
+              "name": "--prerelease",
+              "tip": [
+                "包含预发布包。"
+              ]
+            },
+            {
+              "name": "--skip",
+              "usage": [
+                "--skip <SKIP>"
+              ],
+              "tip": [
+                "要跳过的结果数，用于分页。默认 0。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--source",
+              "usage": [
+                "--source <SOURCE>"
+              ],
+              "tip": [
+                "要搜索的包源。你可以传递多个 `--source` 选项以搜索多个包源。"
+              ],
+              "repeat": 99,
+              "next": []
+            },
+            {
+              "name": "--take",
+              "usage": [
+                "--take <TAKE>"
+              ],
+              "tip": [
+                "要返回的结果数。默认 20。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "usage": [
+                "--verbosity <LEVEL>"
+              ],
+              "tip": [
+                "在输出中显示此数量的详细信息：`normal`、`minimal`、`detailed`。默认值为 `normal`。"
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "update",
+          "usage": [
+            "update [<PACKAGES>]"
+          ],
+          "tip": [
+            "更新项目或解决方案中引用的包。"
+          ],
+          "option": [
+            {
+              "name": "--interactive",
+              "tip": [
+                "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+              ]
+            },
+            {
+              "name": "--project",
+              "alias": [
+                "--file"
+              ],
+              "usage": [
+                "--file, --project <PROJECT>"
+              ],
+              "tip": [
+                "项目或解决方案文件、文件型应用或项目目录的路径。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "设置命令的详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。"
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            },
+            {
+              "name": "--vulnerable",
+              "tip": [
+                "升级具有已知漏洞的包。"
+              ]
+            }
           ]
         }
       ]
@@ -288,31 +4378,498 @@
     {
       "name": "publish",
       "tip": [
-        "发布 .NET 框架依赖或自包含的应用程序。"
+        "发布 .NET 项目进行部署。"
+      ],
+      "option": [
+        {
+          "name": "--arch",
+          "alias": [
+            "-a"
+          ],
+          "usage": [
+            "-a, --arch <ARCH>"
+          ],
+          "tip": [
+            "目标体系结构。"
+          ],
+          "next": [
+            {
+              "name": "arm",
+              "tip": [
+                "ARM32 "
+              ]
+            },
+            {
+              "name": "arm64",
+              "tip": [
+                "ARM64 "
+              ]
+            },
+            {
+              "name": "x64",
+              "tip": [
+                "64 位 x86"
+              ]
+            },
+            {
+              "name": "x86",
+              "tip": [
+                "32 位 x86"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--artifacts-path",
+          "usage": [
+            "--artifacts-path <ARTIFACTS_DIR>"
+          ],
+          "tip": [
+            "产物路径。项目的所有输出（包括生成、发布和打包输出）都将放到指定路径下的子文件夹中。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--configuration",
+          "alias": [
+            "-c"
+          ],
+          "usage": [
+            "-c, --configuration <CONFIGURATION>"
+          ],
+          "tip": [
+            "要为其发布的配置。对于 NET 8.0 及更高版本的项目，默认值为 'Release'；对于较旧项目，默认值为 'Debug'。"
+          ],
+          "next": [
+            {
+              "name": "Debug"
+            },
+            {
+              "name": "Release"
+            }
+          ]
+        },
+        {
+          "name": "--disable-build-servers",
+          "tip": [
+            "强制命令忽略任何永久性生成服务器。"
+          ]
+        },
+        {
+          "name": "--framework",
+          "alias": [
+            "-f"
+          ],
+          "usage": [
+            "-f, --framework <FRAMEWORK>"
+          ],
+          "tip": [
+            "要为其发布的 目标框架。必须在项目文件中指定目标框架。"
+          ],
+          "next": [
+            {
+              "name": "net10.0",
+              "tip": [
+                ".NET 10 "
+              ]
+            },
+            {
+              "name": "net8.0",
+              "tip": [
+                ".NET 8 "
+              ]
+            },
+            {
+              "name": "net9.0",
+              "tip": [
+                ".NET 9 "
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--interactive",
+          "tip": [
+            "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+          ]
+        },
+        {
+          "name": "--manifest",
+          "usage": [
+            "--manifest <MANIFEST>"
+          ],
+          "tip": [
+            "目标清单文件的路径，该文件包含要从发布步骤中排除的包列表。"
+          ],
+          "repeat": 99,
+          "next": []
+        },
+        {
+          "name": "--no-build",
+          "tip": [
+            "发布前不生成项目。隐含 --no-restore。"
+          ]
+        },
+        {
+          "name": "--no-logo",
+          "alias": [
+            "-nologo"
+          ],
+          "usage": [
+            "-nologo, --no-logo"
+          ],
+          "tip": [
+            "不显示启动横幅或版权消息。"
+          ]
+        },
+        {
+          "name": "--no-restore",
+          "tip": [
+            "生成前不还原项目。"
+          ]
+        },
+        {
+          "name": "--no-self-contained",
+          "tip": [
+            "将应用程序发布为依赖框架的应用程序。目标计算机上必须安装兼容的 .NET 运行时才能运行该应用程序。"
+          ]
+        },
+        {
+          "name": "--os",
+          "usage": [
+            "--os <OS>"
+          ],
+          "tip": [
+            "目标操作系统。"
+          ],
+          "next": [
+            {
+              "name": "linux",
+              "tip": [
+                "Linux "
+              ]
+            },
+            {
+              "name": "osx",
+              "tip": [
+                "macOS "
+              ]
+            },
+            {
+              "name": "win",
+              "tip": [
+                "Windows "
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--output",
+          "alias": [
+            "-o"
+          ],
+          "usage": [
+            "-o, --output <OUTPUT_DIR>"
+          ],
+          "tip": [
+            "放置已发布产物的输出目录。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--runtime",
+          "alias": [
+            "-r"
+          ],
+          "usage": [
+            "-r, --runtime <RUNTIME_IDENTIFIER>"
+          ],
+          "tip": [
+            "要为其发布的目标运行时。创建自包含部署时使用此选项。",
+            "默认发布依赖框架的应用程序。"
+          ],
+          "next": [
+            {
+              "name": "linux-arm64",
+              "tip": [
+                "Linux ARM64 "
+              ]
+            },
+            {
+              "name": "linux-x64",
+              "tip": [
+                "Linux x64 "
+              ]
+            },
+            {
+              "name": "osx-arm64",
+              "tip": [
+                "macOS ARM64 "
+              ]
+            },
+            {
+              "name": "osx-x64",
+              "tip": [
+                "macOS x64 "
+              ]
+            },
+            {
+              "name": "win-x64",
+              "tip": [
+                "Windows x64 "
+              ]
+            },
+            {
+              "name": "win-x86",
+              "tip": [
+                "Windows x86 "
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--self-contained",
+          "alias": [
+            "--sc"
+          ],
+          "usage": [
+            "--sc, --self-contained"
+          ],
+          "tip": [
+            "随应用程序发布 .NET 运行时，这样无需在目标计算机上安装运行时。",
+            "默认值为 'false'。但在面向 .NET 7 或更低版本时，如果指定了运行时标识符，默认值为 'true'。"
+          ]
+        },
+        {
+          "name": "--use-current-runtime",
+          "alias": [
+            "--ucr"
+          ],
+          "usage": [
+            "--ucr, --use-current-runtime"
+          ],
+          "tip": [
+            "使用当前运行时作为目标运行时。"
+          ]
+        },
+        {
+          "name": "--verbosity",
+          "alias": [
+            "-verbosity",
+            "-v"
+          ],
+          "usage": [
+            "-v, -verbosity, --verbosity <LEVEL>"
+          ],
+          "tip": [
+            "设置 MSBuild 详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。"
+          ],
+          "next": [
+            {
+              "name": "detailed"
+            },
+            {
+              "name": "diagnostic"
+            },
+            {
+              "name": "minimal"
+            },
+            {
+              "name": "normal"
+            },
+            {
+              "name": "quiet"
+            }
+          ]
+        },
+        {
+          "name": "--version-suffix",
+          "usage": [
+            "--version-suffix <VERSION_SUFFIX>"
+          ],
+          "tip": [
+            "设置生成项目时使用的 $(VersionSuffix) 属性的值。"
+          ],
+          "next": []
+        }
       ]
     },
     {
       "name": "reference",
       "tip": [
-        "用于操作项目引用的 .NET 命令"
+        "添加、移除或列出 .NET 项目的 ProjectReferences。"
+      ],
+      "option": [
+        {
+          "name": "--project",
+          "usage": [
+            "--project <PROJECT>"
+          ],
+          "tip": [
+            "要操作的项目文件。如果未指定文件，命令将在当前目录中搜索一个。"
+          ],
+          "next": []
+        }
       ],
       "next": [
         {
           "name": "add",
+          "usage": [
+            "add <PROJECT_PATH>"
+          ],
           "tip": [
-            "添加项目引用。"
+            "向项目添加项目到项目的引用。"
+          ],
+          "option": [
+            {
+              "name": "--file",
+              "usage": [
+                "--file <FILE>"
+              ],
+              "tip": [
+                "要操作的文件型应用。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--framework",
+              "alias": [
+                "-f"
+              ],
+              "usage": [
+                "-f, --framework <FRAMEWORK>"
+              ],
+              "tip": [
+                "仅在面向特定框架时添加引用。"
+              ],
+              "next": [
+                {
+                  "name": "net10.0",
+                  "tip": [
+                    ".NET 10 "
+                  ]
+                },
+                {
+                  "name": "net8.0",
+                  "tip": [
+                    ".NET 8 "
+                  ]
+                },
+                {
+                  "name": "net9.0",
+                  "tip": [
+                    ".NET 9 "
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+              ]
+            },
+            {
+              "name": "--project",
+              "usage": [
+                "--project <PROJECT>"
+              ],
+              "tip": [
+                "要操作的项目文件。如果未指定文件，命令将在当前目录中搜索一个。"
+              ],
+              "next": []
+            }
           ]
         },
         {
           "name": "list",
           "tip": [
-            "列出项目引用。"
+            "列出项目的所有项目到项目引用。"
+          ],
+          "option": [
+            {
+              "name": "--file",
+              "usage": [
+                "--file <FILE>"
+              ],
+              "tip": [
+                "要操作的文件型应用。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--project",
+              "usage": [
+                "--project <PROJECT>"
+              ],
+              "tip": [
+                "要操作的项目文件。如果未指定文件，命令将在当前目录中搜索一个。"
+              ],
+              "next": []
+            }
           ]
         },
         {
           "name": "remove",
+          "usage": [
+            "remove <PROJECT_PATH>"
+          ],
           "tip": [
-            "移除项目引用。"
+            "从项目移除项目到项目的引用。"
+          ],
+          "option": [
+            {
+              "name": "--file",
+              "usage": [
+                "--file <FILE>"
+              ],
+              "tip": [
+                "要操作的文件型应用。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--framework",
+              "alias": [
+                "-f"
+              ],
+              "usage": [
+                "-f, --framework <FRAMEWORK>"
+              ],
+              "tip": [
+                "仅在面向特定框架时移除引用。"
+              ],
+              "next": [
+                {
+                  "name": "net10.0",
+                  "tip": [
+                    ".NET 10 "
+                  ]
+                },
+                {
+                  "name": "net8.0",
+                  "tip": [
+                    ".NET 8 "
+                  ]
+                },
+                {
+                  "name": "net9.0",
+                  "tip": [
+                    ".NET 9 "
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "--project",
+              "usage": [
+                "--project <PROJECT>"
+              ],
+              "tip": [
+                "要操作的项目文件。如果未指定文件，命令将在当前目录中搜索一个。"
+              ],
+              "next": []
+            }
           ]
         }
       ]
@@ -320,83 +4877,3740 @@
     {
       "name": "restore",
       "tip": [
-        "还原给定应用程序的依赖项。"
-      ]
-    },
-    {
-      "name": "run",
-      "tip": [
-        "从源代码运行应用程序。"
-      ]
-    },
-    {
-      "name": "sdk",
-      "tip": [
-        "用于 SDK 的 .NET 命令。"
+        "还原 .NET 项目中指定的依赖项。"
       ],
-      "next": [
+      "option": [
         {
-          "name": "check",
+          "name": "--arch",
+          "alias": [
+            "-a"
+          ],
+          "usage": [
+            "-a, --arch <ARCH>"
+          ],
           "tip": [
-            "显示已安装的 SDK 和运行时版本的最新状态。"
+            "目标体系结构。"
+          ],
+          "next": [
+            {
+              "name": "arm",
+              "tip": [
+                "ARM32 "
+              ]
+            },
+            {
+              "name": "arm64",
+              "tip": [
+                "ARM64 "
+              ]
+            },
+            {
+              "name": "x64",
+              "tip": [
+                "64 位 x86"
+              ]
+            },
+            {
+              "name": "x86",
+              "tip": [
+                "32 位 x86"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--artifacts-path",
+          "usage": [
+            "--artifacts-path <ARTIFACTS_DIR>"
+          ],
+          "tip": [
+            "产物路径。项目的所有输出（包括生成、发布和打包输出）都将放到指定路径下的子文件夹中。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--configfile",
+          "usage": [
+            "--configfile <FILE>"
+          ],
+          "tip": [
+            "要使用的 NuGet 配置文件。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--disable-build-servers",
+          "tip": [
+            "强制命令忽略任何永久性生成服务器。"
+          ]
+        },
+        {
+          "name": "--disable-parallel",
+          "tip": [
+            "阻止并行还原多个项目。"
+          ]
+        },
+        {
+          "name": "--force",
+          "alias": [
+            "-f"
+          ],
+          "usage": [
+            "-f, --force"
+          ],
+          "tip": [
+            "即使上次还原成功，也强制解析所有依赖项。",
+            "这等效于删除 project.assets.json。"
+          ]
+        },
+        {
+          "name": "--force-evaluate",
+          "tip": [
+            "即使锁文件已存在，也强制还原重新评估所有依赖项。"
+          ]
+        },
+        {
+          "name": "--ignore-failed-sources",
+          "tip": [
+            "将包源失败视为警告。"
+          ]
+        },
+        {
+          "name": "--interactive",
+          "tip": [
+            "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+          ]
+        },
+        {
+          "name": "--lock-file-path",
+          "usage": [
+            "--lock-file-path <LOCK_FILE_PATH>"
+          ],
+          "tip": [
+            "写入项目锁文件的输出位置。默认情况下为 'PROJECT_ROOT\\packages.lock.json'。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--locked-mode",
+          "tip": [
+            "不允许更新项目锁文件。"
+          ]
+        },
+        {
+          "name": "--no-dependencies",
+          "tip": [
+            "不还原项目到项目的引用，仅还原指定的项目。"
+          ]
+        },
+        {
+          "name": "--no-http-cache",
+          "tip": [
+            "禁用包的 HTTP 缓存。"
+          ]
+        },
+        {
+          "name": "--no-logo",
+          "alias": [
+            "-nologo"
+          ],
+          "usage": [
+            "-nologo, --no-logo"
+          ],
+          "tip": [
+            "不显示启动横幅或版权消息。"
+          ]
+        },
+        {
+          "name": "--os",
+          "usage": [
+            "--os <OS>"
+          ],
+          "tip": [
+            "目标操作系统。"
+          ],
+          "next": [
+            {
+              "name": "linux",
+              "tip": [
+                "Linux "
+              ]
+            },
+            {
+              "name": "osx",
+              "tip": [
+                "macOS "
+              ]
+            },
+            {
+              "name": "win",
+              "tip": [
+                "Windows "
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--packages",
+          "usage": [
+            "--packages <PACKAGES_DIR>"
+          ],
+          "tip": [
+            "要将包还原到的目录。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--runtime",
+          "alias": [
+            "-r"
+          ],
+          "usage": [
+            "-r, --runtime <RUNTIME_IDENTIFIER>"
+          ],
+          "tip": [
+            "要为其还原包的目标运行时。"
+          ],
+          "next": [
+            {
+              "name": "linux-x64",
+              "tip": [
+                "Linux x64 "
+              ]
+            },
+            {
+              "name": "osx-arm64",
+              "tip": [
+                "macOS ARM64 "
+              ]
+            },
+            {
+              "name": "win-x64",
+              "tip": [
+                "Windows x64 "
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--source",
+          "alias": [
+            "-s"
+          ],
+          "usage": [
+            "-s, --source <SOURCE>"
+          ],
+          "tip": [
+            "还原时使用的 NuGet 包源。"
+          ],
+          "repeat": 99,
+          "next": []
+        },
+        {
+          "name": "--use-current-runtime",
+          "alias": [
+            "--ucr"
+          ],
+          "usage": [
+            "--ucr, --use-current-runtime"
+          ],
+          "tip": [
+            "使用当前运行时作为目标运行时。"
+          ]
+        },
+        {
+          "name": "--use-lock-file",
+          "tip": [
+            "启用生成项目锁文件并与还原一起使用。"
+          ]
+        },
+        {
+          "name": "--verbosity",
+          "alias": [
+            "-v"
+          ],
+          "usage": [
+            "-v, --verbosity <LEVEL>"
+          ],
+          "tip": [
+            "设置 MSBuild 详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。[默认值: minimal]"
+          ],
+          "next": [
+            {
+              "name": "detailed"
+            },
+            {
+              "name": "diagnostic"
+            },
+            {
+              "name": "minimal"
+            },
+            {
+              "name": "normal"
+            },
+            {
+              "name": "quiet"
+            }
           ]
         }
       ]
     },
     {
-      "name": "sln",
+      "name": "run",
       "tip": [
-        "用于在解决方案文件中添加、移除和列出项目的选项。"
+        "生成并运行 .NET 项目输出。"
+      ],
+      "option": [
+        {
+          "name": "--arch",
+          "alias": [
+            "-a"
+          ],
+          "usage": [
+            "-a, --arch <ARCH>"
+          ],
+          "tip": [
+            "目标体系结构。"
+          ],
+          "next": [
+            {
+              "name": "arm",
+              "tip": [
+                "ARM32 "
+              ]
+            },
+            {
+              "name": "arm64",
+              "tip": [
+                "ARM64 "
+              ]
+            },
+            {
+              "name": "x64",
+              "tip": [
+                "64 位 x86"
+              ]
+            },
+            {
+              "name": "x86",
+              "tip": [
+                "32 位 x86"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--artifacts-path",
+          "usage": [
+            "--artifacts-path <ARTIFACTS_DIR>"
+          ],
+          "tip": [
+            "产物路径。项目的所有输出（包括生成、发布和打包输出）都将放到指定路径下的子文件夹中。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--configuration",
+          "alias": [
+            "-c"
+          ],
+          "usage": [
+            "-c, --configuration <CONFIGURATION>"
+          ],
+          "tip": [
+            "要运行的配置。大多数项目的默认值为 'Debug'。"
+          ],
+          "next": [
+            {
+              "name": "Debug"
+            },
+            {
+              "name": "Release"
+            }
+          ]
+        },
+        {
+          "name": "--device",
+          "usage": [
+            "--device <DEVICE>"
+          ],
+          "tip": [
+            "用于运行应用程序的设备标识符。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--disable-build-servers",
+          "tip": [
+            "强制命令忽略任何永久性生成服务器。"
+          ]
+        },
+        {
+          "name": "--environment",
+          "alias": [
+            "-e"
+          ],
+          "usage": [
+            "-e, --environment <NAME=VALUE>"
+          ],
+          "tip": [
+            "设置环境变量的值。",
+            "如果变量不存在则创建，如果存在则覆盖。",
+            "可以多次指定此参数以提供多个变量。"
+          ],
+          "repeat": 99,
+          "next": []
+        },
+        {
+          "name": "--file",
+          "usage": [
+            "--file <FILE_PATH>"
+          ],
+          "tip": [
+            "要运行的文件型应用的路径（如果当前目录中没有项目，也可以作为第一个参数传递）。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--framework",
+          "alias": [
+            "-f"
+          ],
+          "usage": [
+            "-f, --framework <FRAMEWORK>"
+          ],
+          "tip": [
+            "要为其运行的目标框架。项目文件中还必须指定目标框架。"
+          ],
+          "next": [
+            {
+              "name": "net10.0",
+              "tip": [
+                ".NET 10 "
+              ]
+            },
+            {
+              "name": "net8.0",
+              "tip": [
+                ".NET 8 "
+              ]
+            },
+            {
+              "name": "net9.0",
+              "tip": [
+                ".NET 9 "
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--interactive",
+          "tip": [
+            "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+          ]
+        },
+        {
+          "name": "--launch-profile",
+          "alias": [
+            "-lp"
+          ],
+          "usage": [
+            "-lp, --launch-profile <LAUNCH_PROFILE>"
+          ],
+          "tip": [
+            "启动应用程序时要使用的启动配置文件名称（如果有）。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--list-devices",
+          "tip": [
+            "列出可用于运行应用程序的设备。"
+          ]
+        },
+        {
+          "name": "--no-build",
+          "tip": [
+            "运行前不生成项目。隐含 --no-restore。"
+          ]
+        },
+        {
+          "name": "--no-cache",
+          "tip": [
+            "跳过最新检查，运行前始终生成程序。"
+          ]
+        },
+        {
+          "name": "--no-launch-profile",
+          "tip": [
+            "不要尝试使用 launchSettings.json 或 [app].run.json 来配置应用程序。"
+          ]
+        },
+        {
+          "name": "--no-restore",
+          "tip": [
+            "生成前不还原项目。"
+          ]
+        },
+        {
+          "name": "--no-self-contained",
+          "tip": [
+            "将应用程序发布为依赖框架的应用程序。目标计算机上必须安装兼容的 .NET 运行时才能运行该应用程序。"
+          ]
+        },
+        {
+          "name": "--os",
+          "usage": [
+            "--os <OS>"
+          ],
+          "tip": [
+            "目标操作系统。"
+          ],
+          "next": [
+            {
+              "name": "linux",
+              "tip": [
+                "Linux "
+              ]
+            },
+            {
+              "name": "osx",
+              "tip": [
+                "macOS "
+              ]
+            },
+            {
+              "name": "win",
+              "tip": [
+                "Windows "
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--project",
+          "usage": [
+            "--project <PROJECT_PATH>"
+          ],
+          "tip": [
+            "定义要运行的项目文件的路径。使用项目文件的路径或包含项目文件的目录的路径。如果未指定，默认为当前目录。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--runtime",
+          "alias": [
+            "-r"
+          ],
+          "usage": [
+            "-r, --runtime <RUNTIME_IDENTIFIER>"
+          ],
+          "tip": [
+            "要为其运行的目标运行时。"
+          ],
+          "next": [
+            {
+              "name": "linux-x64",
+              "tip": [
+                "Linux x64 "
+              ]
+            },
+            {
+              "name": "osx-arm64",
+              "tip": [
+                "macOS ARM64 "
+              ]
+            },
+            {
+              "name": "win-x64",
+              "tip": [
+                "Windows x64 "
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--self-contained",
+          "alias": [
+            "--sc"
+          ],
+          "usage": [
+            "--sc, --self-contained"
+          ],
+          "tip": [
+            "随应用程序发布 .NET 运行时，这样无需在目标计算机上安装运行时。",
+            "默认值为 'false'。但在面向 .NET 7 或更低版本时，如果指定了运行时标识符，默认值为 'true'。"
+          ]
+        },
+        {
+          "name": "--verbosity",
+          "alias": [
+            "-verbosity",
+            "-v"
+          ],
+          "usage": [
+            "-v, -verbosity, --verbosity <LEVEL>"
+          ],
+          "tip": [
+            "设置 MSBuild 详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。"
+          ],
+          "next": [
+            {
+              "name": "detailed"
+            },
+            {
+              "name": "diagnostic"
+            },
+            {
+              "name": "minimal"
+            },
+            {
+              "name": "normal"
+            },
+            {
+              "name": "quiet"
+            }
+          ]
+        }
       ]
     },
     {
-      "name": "store",
+      "name": "sdk",
       "tip": [
-        "将程序集存储到运行时包存储库中。"
-      ]
-    },
-    {
-      "name": "test",
-      "tip": [
-        "使用测试运行程序运行测试。"
-      ]
-    },
-    {
-      "name": "tool",
-      "tip": [
-        "安装或使用扩展 .NET 体验的工具。",
-        "工具是从 NuGet 包安装并在命令行中调用的控制台应用程序。",
-        "你可以自己编写工具，也可以安装第三方编写的工具。"
+        "管理 .NET SDK 安装。"
       ],
       "next": [
         {
-          "name": "install",
+          "name": "check",
           "tip": [
-            "在你的计算机上安装工具。"
+            "显示已安装功能带的 SDK 和运行时版本的最新可用状态。"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "solution",
+      "alias": [
+        "sln"
+      ],
+      "usage": [
+        "sln|solution [<SLN_FILE>]"
+      ],
+      "tip": [
+        "修改 Visual Studio 解决方案文件。"
+      ],
+      "next": [
+        {
+          "name": "add",
+          "usage": [
+            "add <PROJECT_PATH>"
+          ],
+          "tip": [
+            "向解决方案文件添加一个或多个项目。"
+          ],
+          "option": [
+            {
+              "name": "--in-root",
+              "tip": [
+                "将项目放在解决方案根目录中，而不是创建解决方案文件夹。"
+              ]
+            },
+            {
+              "name": "--include-references",
+              "tip": [
+                "将项目的 ReferencedProjects 递归添加到解决方案。"
+              ]
+            },
+            {
+              "name": "--solution-folder",
+              "alias": [
+                "-s"
+              ],
+              "usage": [
+                "-s, --solution-folder <SOLUTION_FOLDER>"
+              ],
+              "tip": [
+                "要将项目添加到的目标解决方案文件夹路径。"
+              ],
+              "next": []
+            }
           ]
         },
         {
           "name": "list",
           "tip": [
-            "列出当前安装在你计算机上的所有全局工具、工具路径工具或本地工具。"
+            "列出解决方案文件中的所有项目。"
+          ],
+          "option": [
+            {
+              "name": "--solution-folders",
+              "tip": [
+                "显示解决方案文件夹路径。"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "migrate",
+          "tip": [
+            "根据 .sln 文件生成 .slnx 文件。"
+          ]
+        },
+        {
+          "name": "remove",
+          "usage": [
+            "remove <PROJECT_PATH>"
+          ],
+          "tip": [
+            "从解决方案文件移除一个或多个项目。"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "store",
+      "tip": [
+        "将指定的程序集存储到运行时包存储中。"
+      ],
+      "option": [
+        {
+          "name": "--disable-build-servers",
+          "tip": [
+            "强制命令忽略任何永久性生成服务器。"
+          ]
+        },
+        {
+          "name": "--framework",
+          "alias": [
+            "-f"
+          ],
+          "usage": [
+            "-f, --framework <FRAMEWORK>"
+          ],
+          "tip": [
+            "要为其存储包的目标框架。必须在项目文件中指定目标框架。"
+          ],
+          "next": [
+            {
+              "name": "net10.0",
+              "tip": [
+                ".NET 10 "
+              ]
+            },
+            {
+              "name": "net8.0",
+              "tip": [
+                ".NET 8 "
+              ]
+            },
+            {
+              "name": "net9.0",
+              "tip": [
+                ".NET 9 "
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--framework-version",
+          "usage": [
+            "--framework-version <FRAMEWORK_VERSION>"
+          ],
+          "tip": [
+            "用于运行程序集的 Microsoft.NETCore.App 包版本。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--manifest",
+          "alias": [
+            "-m"
+          ],
+          "usage": [
+            "-m, --manifest <PROJECT_MANIFEST>"
+          ],
+          "tip": [
+            "包含要存储的包列表的 XML 文件。"
+          ],
+          "repeat": 99,
+          "next": []
+        },
+        {
+          "name": "--no-logo",
+          "alias": [
+            "-nologo"
+          ],
+          "usage": [
+            "-nologo, --no-logo"
+          ],
+          "tip": [
+            "不显示启动横幅或版权消息。"
+          ]
+        },
+        {
+          "name": "--output",
+          "alias": [
+            "-o"
+          ],
+          "usage": [
+            "-o, --output <OUTPUT_DIR>"
+          ],
+          "tip": [
+            "存储给定程序集的输出目录。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--runtime",
+          "alias": [
+            "-r"
+          ],
+          "usage": [
+            "-r, --runtime <RUNTIME_IDENTIFIER>"
+          ],
+          "tip": [
+            "要为其存储包的目标运行时。"
+          ],
+          "next": [
+            {
+              "name": "linux-x64",
+              "tip": [
+                "Linux x64 "
+              ]
+            },
+            {
+              "name": "osx-arm64",
+              "tip": [
+                "macOS ARM64 "
+              ]
+            },
+            {
+              "name": "win-x64",
+              "tip": [
+                "Windows x64 "
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--skip-optimization",
+          "tip": [
+            "跳过优化阶段。"
+          ]
+        },
+        {
+          "name": "--skip-symbols",
+          "tip": [
+            "跳过创建可用于分析已优化程序集的符号文件。"
+          ]
+        },
+        {
+          "name": "--use-current-runtime",
+          "alias": [
+            "--ucr"
+          ],
+          "usage": [
+            "--ucr, --use-current-runtime"
+          ],
+          "tip": [
+            "使用当前运行时作为目标运行时。"
+          ]
+        },
+        {
+          "name": "--verbosity",
+          "alias": [
+            "-verbosity",
+            "-v"
+          ],
+          "usage": [
+            "-v, -verbosity, --verbosity <LEVEL>"
+          ],
+          "tip": [
+            "设置 MSBuild 详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。"
+          ],
+          "next": [
+            {
+              "name": "detailed"
+            },
+            {
+              "name": "diagnostic"
+            },
+            {
+              "name": "minimal"
+            },
+            {
+              "name": "normal"
+            },
+            {
+              "name": "quiet"
+            }
+          ]
+        },
+        {
+          "name": "--working-dir",
+          "alias": [
+            "-w"
+          ],
+          "usage": [
+            "-w, --working-dir <WORKING_DIR>"
+          ],
+          "tip": [
+            "命令执行时使用的工作目录。"
+          ],
+          "next": []
+        }
+      ]
+    },
+    {
+      "name": "test",
+      "tip": [
+        "使用 .NET 项目中指定的测试运行程序运行单元测试。"
+      ],
+      "option": [
+        {
+          "name": "--arch",
+          "alias": [
+            "-a"
+          ],
+          "usage": [
+            "-a, --arch <ARCH>"
+          ],
+          "tip": [
+            "目标体系结构。"
+          ],
+          "next": [
+            {
+              "name": "arm",
+              "tip": [
+                "ARM32 "
+              ]
+            },
+            {
+              "name": "arm64",
+              "tip": [
+                "ARM64 "
+              ]
+            },
+            {
+              "name": "x64",
+              "tip": [
+                "64 位 x86"
+              ]
+            },
+            {
+              "name": "x86",
+              "tip": [
+                "32 位 x86"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--artifacts-path",
+          "usage": [
+            "--artifacts-path <ARTIFACTS_DIR>"
+          ],
+          "tip": [
+            "产物路径。项目的所有输出（包括生成、发布和打包输出）都将放到指定路径下的子文件夹中。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--blame",
+          "tip": [
+            "在 blame 模式下运行测试。此选项有助于隔离导致测试主机崩溃或挂起的可疑测试。"
+          ]
+        },
+        {
+          "name": "--blame-crash",
+          "tip": [
+            "在 blame 模式下运行测试，并在测试主机意外退出时收集崩溃转储。隐含 --blame。"
+          ]
+        },
+        {
+          "name": "--blame-crash-collect-always",
+          "tip": [
+            "启用对预期和非预期 testhost 退出的崩溃转储收集。"
+          ]
+        },
+        {
+          "name": "--blame-crash-dump-type",
+          "usage": [
+            "--blame-crash-dump-type <DUMP_TYPE>"
+          ],
+          "tip": [
+            "要收集的崩溃转储类型。支持的值是 full（默认）和 mini。隐含 --blame-crash。"
+          ],
+          "next": [
+            {
+              "name": "full"
+            },
+            {
+              "name": "mini"
+            }
+          ]
+        },
+        {
+          "name": "--blame-hang",
+          "tip": [
+            "在 blame 模式下运行测试，并在测试超过给定超时时启用挂起转储收集。"
+          ]
+        },
+        {
+          "name": "--blame-hang-dump-type",
+          "usage": [
+            "--blame-hang-dump-type <DUMP_TYPE>"
+          ],
+          "tip": [
+            "要收集的挂起转储类型。支持的值是 full（默认）、mini 和 none。隐含 --blame-hang。"
+          ],
+          "next": [
+            {
+              "name": "full"
+            },
+            {
+              "name": "mini"
+            },
+            {
+              "name": "none"
+            }
+          ]
+        },
+        {
+          "name": "--blame-hang-timeout",
+          "usage": [
+            "--blame-hang-timeout <TIMESPAN>"
+          ],
+          "tip": [
+            "每个测试的超时时间，超过后触发挂起转储并终止 testhost 进程。默认为 1h。",
+            "超时值按以下格式指定：1.5h / 90m / 5400s / 5400000ms。"
+          ],
+          "next": [
+            {
+              "name": "10m",
+              "tip": [
+                "10 分钟"
+              ]
+            },
+            {
+              "name": "1h",
+              "tip": [
+                "1 小时"
+              ]
+            },
+            {
+              "name": "1m",
+              "tip": [
+                "1 分钟"
+              ]
+            },
+            {
+              "name": "30m",
+              "tip": [
+                "30 分钟"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--collect",
+          "usage": [
+            "--collect <DATA_COLLECTOR_NAME>"
+          ],
+          "tip": [
+            "测试运行使用的数据收集器的友好名称。"
+          ],
+          "next": [
+            {
+              "name": "\"Code Coverage\"",
+              "tip": [
+                "代码覆盖率数据收集器"
+              ]
+            },
+            {
+              "name": "\"XPlat Code Coverage\"",
+              "tip": [
+                "跨平台代码覆盖率数据收集器"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--configuration",
+          "alias": [
+            "-c"
+          ],
+          "usage": [
+            "-c, --configuration <CONFIGURATION>"
+          ],
+          "tip": [
+            "运行测试时使用的配置。大多数项目的默认值为 'Debug'。"
+          ],
+          "next": [
+            {
+              "name": "Debug"
+            },
+            {
+              "name": "Release"
+            }
+          ]
+        },
+        {
+          "name": "--diag",
+          "alias": [
+            "-d"
+          ],
+          "usage": [
+            "-d, --diag <LOG_FILE>"
+          ],
+          "tip": [
+            "启用详细日志记录到指定的文件。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--disable-build-servers",
+          "tip": [
+            "强制命令忽略任何永久性生成服务器。"
+          ]
+        },
+        {
+          "name": "--environment",
+          "alias": [
+            "-e"
+          ],
+          "usage": [
+            "-e, --environment <NAME=VALUE>"
+          ],
+          "tip": [
+            "设置环境变量的值。",
+            "如果变量不存在则创建，如果存在则覆盖。",
+            "这将强制测试在隔离进程中运行。",
+            "可以多次指定此参数以提供多个变量。"
+          ],
+          "repeat": 99,
+          "next": []
+        },
+        {
+          "name": "--filter",
+          "usage": [
+            "--filter <EXPRESSION>"
+          ],
+          "tip": [
+            "运行与给定表达式匹配的测试。",
+            "示例：--filter \"FullyQualifiedName~Namespace.Class\"。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--framework",
+          "alias": [
+            "-f"
+          ],
+          "usage": [
+            "-f, --framework <FRAMEWORK>"
+          ],
+          "tip": [
+            "要为其运行测试的目标框架。项目文件中还必须指定目标框架。"
+          ],
+          "next": [
+            {
+              "name": "net10.0",
+              "tip": [
+                ".NET 10 "
+              ]
+            },
+            {
+              "name": "net8.0",
+              "tip": [
+                ".NET 8 "
+              ]
+            },
+            {
+              "name": "net9.0",
+              "tip": [
+                ".NET 9 "
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--interactive",
+          "tip": [
+            "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+          ]
+        },
+        {
+          "name": "--list-tests",
+          "alias": [
+            "-t"
+          ],
+          "usage": [
+            "-t, --list-tests"
+          ],
+          "tip": [
+            "列出发现的测试而不是运行测试。"
+          ]
+        },
+        {
+          "name": "--logger",
+          "alias": [
+            "-l"
+          ],
+          "usage": [
+            "-l, --logger <LOGGER>"
+          ],
+          "tip": [
+            "用于测试结果的记录器。示例：trx;LogFileName=<TestResults.trx>。"
+          ],
+          "repeat": 99,
+          "next": []
+        },
+        {
+          "name": "--no-build",
+          "tip": [
+            "测试前不生成项目。隐含 --no-restore。"
+          ]
+        },
+        {
+          "name": "--no-logo",
+          "alias": [
+            "-nologo"
+          ],
+          "usage": [
+            "-nologo, --no-logo"
+          ],
+          "tip": [
+            "运行测试时不显示 Microsoft Testplatform 横幅。"
+          ]
+        },
+        {
+          "name": "--no-restore",
+          "tip": [
+            "生成前不还原项目。"
+          ]
+        },
+        {
+          "name": "--os",
+          "usage": [
+            "--os <OS>"
+          ],
+          "tip": [
+            "目标操作系统。"
+          ],
+          "next": [
+            {
+              "name": "linux",
+              "tip": [
+                "Linux "
+              ]
+            },
+            {
+              "name": "osx",
+              "tip": [
+                "macOS "
+              ]
+            },
+            {
+              "name": "win",
+              "tip": [
+                "Windows "
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--output",
+          "alias": [
+            "-o"
+          ],
+          "usage": [
+            "-o, --output <OUTPUT_DIR>"
+          ],
+          "tip": [
+            "放置生成产物的输出目录。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--results-directory",
+          "usage": [
+            "--results-directory <RESULTS_DIR>"
+          ],
+          "tip": [
+            "测试结果将放置到的目录。如果指定目录不存在，将创建它。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--runtime",
+          "alias": [
+            "-r"
+          ],
+          "usage": [
+            "-r, --runtime <RUNTIME_IDENTIFIER>"
+          ],
+          "tip": [
+            "要为其运行测试的目标运行时。"
+          ],
+          "next": [
+            {
+              "name": "linux-x64",
+              "tip": [
+                "Linux x64 "
+              ]
+            },
+            {
+              "name": "osx-arm64",
+              "tip": [
+                "macOS ARM64 "
+              ]
+            },
+            {
+              "name": "win-x64",
+              "tip": [
+                "Windows x64 "
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--settings",
+          "alias": [
+            "-s"
+          ],
+          "usage": [
+            "-s, --settings <SETTINGS_FILE>"
+          ],
+          "tip": [
+            "运行测试时使用的设置文件。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--test-adapter-path",
+          "usage": [
+            "--test-adapter-path <ADAPTER_PATH>"
+          ],
+          "tip": [
+            "测试运行使用的自定义适配器的路径。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--verbosity",
+          "alias": [
+            "-v"
+          ],
+          "usage": [
+            "-v, --verbosity <LEVEL>"
+          ],
+          "tip": [
+            "设置 MSBuild 详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。"
+          ],
+          "next": [
+            {
+              "name": "detailed"
+            },
+            {
+              "name": "diagnostic"
+            },
+            {
+              "name": "minimal"
+            },
+            {
+              "name": "normal"
+            },
+            {
+              "name": "quiet"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "tool",
+      "tip": [
+        "安装或管理扩展 .NET 体验的工具。",
+        "工具是从 NuGet 包安装并在命令行中调用的控制台应用程序。",
+        "你可以自己编写工具，也可以安装第三方编写的工具。"
+      ],
+      "next": [
+        {
+          "name": "execute",
+          "alias": [
+            "exec"
+          ],
+          "usage": [
+            "exec|execute <PACKAGE_ID>"
+          ],
+          "tip": [
+            "从源执行工具，而无需永久安装它。"
+          ],
+          "option": [
+            {
+              "name": "--add-source",
+              "usage": [
+                "--add-source <SOURCE>"
+              ],
+              "tip": [
+                "在安装期间添加额外的 NuGet 包源。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--allow-roll-forward",
+              "tip": [
+                "如果工具所面向的 .NET 运行时未安装，则允许 .NET 工具前滚到较新版本的 .NET 运行时。"
+              ]
+            },
+            {
+              "name": "--configfile",
+              "usage": [
+                "--configfile <FILE>"
+              ],
+              "tip": [
+                "要使用的 NuGet 配置文件。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--disable-parallel",
+              "tip": [
+                "阻止并行还原多个项目。"
+              ]
+            },
+            {
+              "name": "--ignore-failed-sources",
+              "tip": [
+                "将包源失败视为警告。"
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+              ]
+            },
+            {
+              "name": "--no-http-cache",
+              "tip": [
+                "不缓存包和 http 请求。"
+              ]
+            },
+            {
+              "name": "--prerelease",
+              "tip": [
+                "包含预发布包。"
+              ]
+            },
+            {
+              "name": "--source",
+              "usage": [
+                "--source <SOURCE>"
+              ],
+              "tip": [
+                "用这些源替换安装期间使用的所有 NuGet 包源。"
+              ],
+              "repeat": 99,
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "设置 MSBuild 详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。[默认值: normal]"
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            },
+            {
+              "name": "--version",
+              "usage": [
+                "--version <VERSION>"
+              ],
+              "tip": [
+                "要安装的工具包的版本。"
+              ],
+              "next": []
+            }
+          ]
+        },
+        {
+          "name": "install",
+          "usage": [
+            "install <PACKAGE_ID>"
+          ],
+          "tip": [
+            "安装全局或本地工具。本地工具会添加到清单并进行还原。"
+          ],
+          "option": [
+            {
+              "name": "--add-source",
+              "usage": [
+                "--add-source <SOURCE>"
+              ],
+              "tip": [
+                "在安装期间添加额外的 NuGet 包源。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--allow-downgrade",
+              "tip": [
+                "安装 .NET 工具包时允许包降级。"
+              ]
+            },
+            {
+              "name": "--allow-roll-forward",
+              "tip": [
+                "如果工具所面向的 .NET 运行时未安装，则允许 .NET 工具前滚到较新版本的 .NET 运行时。"
+              ]
+            },
+            {
+              "name": "--arch",
+              "alias": [
+                "-a"
+              ],
+              "usage": [
+                "-a, --arch <ARCH>"
+              ],
+              "tip": [
+                "目标体系结构。"
+              ],
+              "next": [
+                {
+                  "name": "arm64",
+                  "tip": [
+                    "ARM64 "
+                  ]
+                },
+                {
+                  "name": "x64",
+                  "tip": [
+                    "64 位 x86"
+                  ]
+                },
+                {
+                  "name": "x86",
+                  "tip": [
+                    "32 位 x86"
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "--configfile",
+              "usage": [
+                "--configfile <FILE>"
+              ],
+              "tip": [
+                "要使用的 NuGet 配置文件。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--create-manifest-if-needed",
+              "tip": [
+                "如果在工具安装期间找不到工具清单，则创建一个。"
+              ]
+            },
+            {
+              "name": "--disable-parallel",
+              "tip": [
+                "阻止并行还原多个项目。"
+              ]
+            },
+            {
+              "name": "--framework",
+              "usage": [
+                "--framework <FRAMEWORK>"
+              ],
+              "tip": [
+                "要为其安装工具的目标框架。"
+              ],
+              "next": [
+                {
+                  "name": "net10.0",
+                  "tip": [
+                    ".NET 10 "
+                  ]
+                },
+                {
+                  "name": "net8.0",
+                  "tip": [
+                    ".NET 8 "
+                  ]
+                },
+                {
+                  "name": "net9.0",
+                  "tip": [
+                    ".NET 9 "
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "--global",
+              "alias": [
+                "-g"
+              ],
+              "usage": [
+                "-g, --global"
+              ],
+              "tip": [
+                "为当前用户安装工具。"
+              ]
+            },
+            {
+              "name": "--ignore-failed-sources",
+              "tip": [
+                "将包源失败视为警告。"
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+              ]
+            },
+            {
+              "name": "--local",
+              "tip": [
+                "安装工具并添加到本地工具清单（默认）。"
+              ]
+            },
+            {
+              "name": "--no-http-cache",
+              "tip": [
+                "不缓存包和 http 请求。"
+              ]
+            },
+            {
+              "name": "--prerelease",
+              "tip": [
+                "包含预发布包。"
+              ]
+            },
+            {
+              "name": "--source",
+              "usage": [
+                "--source <SOURCE>"
+              ],
+              "tip": [
+                "用这些源替换安装期间使用的所有 NuGet 包源。"
+              ],
+              "repeat": 99,
+              "next": []
+            },
+            {
+              "name": "--tool-manifest",
+              "usage": [
+                "--tool-manifest <PATH>"
+              ],
+              "tip": [
+                "清单文件的路径。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--tool-path",
+              "usage": [
+                "--tool-path <PATH>"
+              ],
+              "tip": [
+                "工具将安装到的目录。如果该目录不存在，将创建它。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "设置 MSBuild 详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。[默认值: normal]"
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            },
+            {
+              "name": "--version",
+              "usage": [
+                "--version <VERSION>"
+              ],
+              "tip": [
+                "要安装的工具包的版本。"
+              ],
+              "next": []
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "usage": [
+            "list [<PACKAGE_ID>]"
+          ],
+          "tip": [
+            "列出全局或本地安装的工具。"
+          ],
+          "option": [
+            {
+              "name": "--format",
+              "usage": [
+                "--format <JSON|TABLE>"
+              ],
+              "tip": [
+                "工具列表的输出格式。[默认值: table]"
+              ],
+              "next": [
+                {
+                  "name": "json"
+                },
+                {
+                  "name": "table"
+                }
+              ]
+            },
+            {
+              "name": "--global",
+              "alias": [
+                "-g"
+              ],
+              "usage": [
+                "-g, --global"
+              ],
+              "tip": [
+                "列出为当前用户安装的工具。"
+              ]
+            },
+            {
+              "name": "--local",
+              "tip": [
+                "列出本地工具清单中安装的工具。"
+              ]
+            },
+            {
+              "name": "--tool-path",
+              "usage": [
+                "--tool-path <PATH>"
+              ],
+              "tip": [
+                "包含要列出的工具的目录。"
+              ],
+              "next": []
+            }
+          ]
+        },
+        {
+          "name": "restore",
+          "tip": [
+            "还原本地工具清单中定义的工具。"
+          ],
+          "option": [
+            {
+              "name": "--add-source",
+              "usage": [
+                "--add-source <SOURCE>"
+              ],
+              "tip": [
+                "在安装期间添加额外的 NuGet 包源。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--configfile",
+              "usage": [
+                "--configfile <FILE>"
+              ],
+              "tip": [
+                "要使用的 NuGet 配置文件。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--disable-parallel",
+              "tip": [
+                "阻止并行还原多个项目。"
+              ]
+            },
+            {
+              "name": "--ignore-failed-sources",
+              "tip": [
+                "将包源失败视为警告。"
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+              ]
+            },
+            {
+              "name": "--no-http-cache",
+              "tip": [
+                "不缓存包和 http 请求。"
+              ]
+            },
+            {
+              "name": "--tool-manifest",
+              "usage": [
+                "--tool-manifest <PATH>"
+              ],
+              "tip": [
+                "清单文件的路径。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "设置 MSBuild 详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。[默认值: normal]"
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "run",
+          "usage": [
+            "run <COMMAND_NAME>"
+          ],
+          "tip": [
+            "运行本地工具。注意：此命令不能用于运行全局工具。"
+          ],
+          "option": [
+            {
+              "name": "--allow-roll-forward",
+              "tip": [
+                "如果工具所面向的 .NET 运行时未安装，则允许 .NET 工具前滚到较新版本的 .NET 运行时。"
+              ]
+            }
           ]
         },
         {
           "name": "search",
+          "usage": [
+            "search <SEARCH_TERM>"
+          ],
           "tip": [
-            "在 NuGet.org 中搜索其名称或元数据中包含指定搜索词的工具。"
+            "在 nuget.org 中搜索 dotnet 工具。"
+          ],
+          "option": [
+            {
+              "name": "--detail",
+              "tip": [
+                "显示查询的详细结果。"
+              ]
+            },
+            {
+              "name": "--prerelease",
+              "tip": [
+                "包含预发布包。"
+              ]
+            },
+            {
+              "name": "--skip",
+              "usage": [
+                "--skip <SKIP>"
+              ],
+              "tip": [
+                "用于分页而要跳过的结果数。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--take",
+              "usage": [
+                "--take <TAKE>"
+              ],
+              "tip": [
+                "用于分页而要返回的结果数。"
+              ],
+              "next": []
+            }
           ]
         },
         {
           "name": "uninstall",
+          "usage": [
+            "uninstall <PACKAGE_ID>"
+          ],
           "tip": [
-            "从你的计算机卸载工具。"
+            "卸载全局工具或本地工具。"
+          ],
+          "option": [
+            {
+              "name": "--global",
+              "alias": [
+                "-g"
+              ],
+              "usage": [
+                "-g, --global"
+              ],
+              "tip": [
+                "从当前用户的工具目录卸载工具。"
+              ]
+            },
+            {
+              "name": "--local",
+              "tip": [
+                "卸载工具并从本地工具清单中移除它。"
+              ]
+            },
+            {
+              "name": "--tool-manifest",
+              "usage": [
+                "--tool-manifest <PATH>"
+              ],
+              "tip": [
+                "清单文件的路径。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--tool-path",
+              "usage": [
+                "--tool-path <PATH>"
+              ],
+              "tip": [
+                "包含要卸载工具的目录。"
+              ],
+              "next": []
+            }
           ]
         },
         {
           "name": "update",
+          "usage": [
+            "update [<PACKAGE_ID>]"
+          ],
           "tip": [
-            "更新安装在你计算机上的工具。"
+            "更新全局或本地工具。"
+          ],
+          "option": [
+            {
+              "name": "--add-source",
+              "usage": [
+                "--add-source <SOURCE>"
+              ],
+              "tip": [
+                "在安装期间添加额外的 NuGet 包源。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--all",
+              "tip": [
+                "更新所有工具。"
+              ]
+            },
+            {
+              "name": "--allow-downgrade",
+              "tip": [
+                "安装 .NET 工具包时允许包降级。"
+              ]
+            },
+            {
+              "name": "--configfile",
+              "usage": [
+                "--configfile <FILE>"
+              ],
+              "tip": [
+                "要使用的 NuGet 配置文件。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--disable-parallel",
+              "tip": [
+                "阻止并行还原多个项目。"
+              ]
+            },
+            {
+              "name": "--framework",
+              "usage": [
+                "--framework <FRAMEWORK>"
+              ],
+              "tip": [
+                "要为其安装工具的目标框架。"
+              ],
+              "next": [
+                {
+                  "name": "net10.0",
+                  "tip": [
+                    ".NET 10 "
+                  ]
+                },
+                {
+                  "name": "net8.0",
+                  "tip": [
+                    ".NET 8 "
+                  ]
+                },
+                {
+                  "name": "net9.0",
+                  "tip": [
+                    ".NET 9 "
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "--global",
+              "alias": [
+                "-g"
+              ],
+              "usage": [
+                "-g, --global"
+              ],
+              "tip": [
+                "为当前用户安装工具。"
+              ]
+            },
+            {
+              "name": "--ignore-failed-sources",
+              "tip": [
+                "将包源失败视为警告。"
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+              ]
+            },
+            {
+              "name": "--local",
+              "tip": [
+                "安装工具并添加到本地工具清单（默认）。"
+              ]
+            },
+            {
+              "name": "--no-http-cache",
+              "tip": [
+                "不缓存包和 http 请求。"
+              ]
+            },
+            {
+              "name": "--prerelease",
+              "tip": [
+                "包含预发布包。"
+              ]
+            },
+            {
+              "name": "--source",
+              "usage": [
+                "--source <SOURCE>"
+              ],
+              "tip": [
+                "用这些源替换安装期间使用的所有 NuGet 包源。"
+              ],
+              "repeat": 99,
+              "next": []
+            },
+            {
+              "name": "--tool-manifest",
+              "usage": [
+                "--tool-manifest <PATH>"
+              ],
+              "tip": [
+                "清单文件的路径。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--tool-path",
+              "usage": [
+                "--tool-path <PATH>"
+              ],
+              "tip": [
+                "工具将安装到的目录。如果该目录不存在，将创建它。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "设置 MSBuild 详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。[默认值: normal]"
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            },
+            {
+              "name": "--version",
+              "usage": [
+                "--version <VERSION>"
+              ],
+              "tip": [
+                "要安装的工具包的版本。"
+              ],
+              "next": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "user-jwts",
+      "tip": [
+        "在开发中管理 JSON Web 令牌。"
+      ],
+      "option": [
+        {
+          "name": "--output",
+          "alias": [
+            "-o"
+          ],
+          "usage": [
+            "-o, --output <FORMAT>"
+          ],
+          "tip": [
+            "用于显示命令输出内容的格式。可以是 'default'、'token' 或 'json'。"
+          ],
+          "next": [
+            {
+              "name": "default"
+            },
+            {
+              "name": "json"
+            },
+            {
+              "name": "token"
+            }
+          ]
+        },
+        {
+          "name": "--project",
+          "alias": [
+            "-p"
+          ],
+          "usage": [
+            "-p, --project <PROJECT>"
+          ],
+          "tip": [
+            "要操作的项目路径。默认为当前目录中的项目。"
+          ],
+          "next": []
+        }
+      ],
+      "next": [
+        {
+          "name": "clear",
+          "tip": [
+            "移除为项目发布的所有 JWT。"
+          ],
+          "option": [
+            {
+              "name": "--appsettings-file",
+              "usage": [
+                "--appsettings-file <FILE>"
+              ],
+              "tip": [
+                "要添加测试方案的 appSettings 配置文件。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--force",
+              "tip": [
+                "删除 JWT 前不提示确认。"
+              ]
+            },
+            {
+              "name": "--output",
+              "alias": [
+                "-o"
+              ],
+              "usage": [
+                "-o, --output <FORMAT>"
+              ],
+              "tip": [
+                "用于显示命令输出内容的格式。可以是 'default'、'token' 或 'json'。"
+              ],
+              "next": [
+                {
+                  "name": "default"
+                },
+                {
+                  "name": "json"
+                },
+                {
+                  "name": "token"
+                }
+              ]
+            },
+            {
+              "name": "--project",
+              "alias": [
+                "-p"
+              ],
+              "usage": [
+                "-p, --project <PROJECT>"
+              ],
+              "tip": [
+                "要操作的项目路径。默认为当前目录中的项目。"
+              ],
+              "next": []
+            }
+          ]
+        },
+        {
+          "name": "create",
+          "tip": [
+            "发布新的 JSON Web 令牌。"
+          ],
+          "option": [
+            {
+              "name": "--appsettings-file",
+              "usage": [
+                "--appsettings-file <FILE>"
+              ],
+              "tip": [
+                "要添加测试方案的 appSettings 配置文件。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--audience",
+              "usage": [
+                "--audience <AUDIENCE>"
+              ],
+              "tip": [
+                "为其创建 JWT 的受众。默认为项目 launchSettings.json 中配置的 URL。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--claim",
+              "usage": [
+                "--claim <NAME=VALUE>"
+              ],
+              "tip": [
+                "要添加到 JWT 的声明。以 \"name=value\" 格式为每个声明指定一次。"
+              ],
+              "repeat": 99,
+              "next": []
+            },
+            {
+              "name": "--expires-on",
+              "usage": [
+                "--expires-on <DATE_TIME>"
+              ],
+              "tip": [
+                "JWT 在格式为 'yyyy-MM-dd [[[[HH:mm]]:ss]]' 时过期的 UTC 日期和时间。不要与此选项与 --valid-for 选项一起使用。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--issuer",
+              "usage": [
+                "--issuer <ISSUER>"
+              ],
+              "tip": [
+                "JWT 的颁发者。默认为 'dotnet-user-jwts'。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--name",
+              "alias": [
+                "-n"
+              ],
+              "usage": [
+                "-n, --name <NAME>"
+              ],
+              "tip": [
+                "为其创建 JWT 的用户名称。默认为当前环境用户。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--not-before",
+              "usage": [
+                "--not-before <DATE_TIME>"
+              ],
+              "tip": [
+                "JWT 在格式为 'yyyy-MM-dd [[HH:mm[[:ss]]]]' 之前应无效的 UTC 日期和时间。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--output",
+              "alias": [
+                "-o"
+              ],
+              "usage": [
+                "-o, --output <FORMAT>"
+              ],
+              "tip": [
+                "用于显示命令输出内容的格式。可以是 'default'、'token' 或 'json'。"
+              ],
+              "next": [
+                {
+                  "name": "default"
+                },
+                {
+                  "name": "json"
+                },
+                {
+                  "name": "token"
+                }
+              ]
+            },
+            {
+              "name": "--project",
+              "alias": [
+                "-p"
+              ],
+              "usage": [
+                "-p, --project <PROJECT>"
+              ],
+              "tip": [
+                "要操作的项目路径。默认为当前目录中的项目。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--role",
+              "usage": [
+                "--role <ROLE>"
+              ],
+              "tip": [
+                "要添加到 JWT 的 role 声明。每个 role 指定一次。"
+              ],
+              "repeat": 99,
+              "next": []
+            },
+            {
+              "name": "--scheme",
+              "usage": [
+                "--scheme <SCHEME>"
+              ],
+              "tip": [
+                "用于生成的令牌的方案名称。默认为 'Bearer'。"
+              ],
+              "next": [
+                {
+                  "name": "Bearer"
+                }
+              ]
+            },
+            {
+              "name": "--scope",
+              "usage": [
+                "--scope <SCOPE>"
+              ],
+              "tip": [
+                "要添加到 JWT 的 scope 声明。每个 scope 指定一次。"
+              ],
+              "repeat": 99,
+              "next": []
+            },
+            {
+              "name": "--valid-for",
+              "usage": [
+                "--valid-for <PERIOD>"
+              ],
+              "tip": [
+                "JWT 过期的时间段。使用数字后跟持续时间类型指定，如 'd' 表示天、'h' 表示小时，例如 '365d'。不要与此选项与 --expires-on 选项一起使用。"
+              ],
+              "next": [
+                {
+                  "name": "1h",
+                  "tip": [
+                    "1 小时"
+                  ]
+                },
+                {
+                  "name": "24h",
+                  "tip": [
+                    "24 小时"
+                  ]
+                },
+                {
+                  "name": "30d",
+                  "tip": [
+                    "30 天"
+                  ]
+                },
+                {
+                  "name": "365d",
+                  "tip": [
+                    "365 天"
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "key",
+          "tip": [
+            "显示或重置用于发布 JWT 的签名密钥。"
+          ],
+          "option": [
+            {
+              "name": "--force",
+              "tip": [
+                "重置签名密钥前不提示确认。"
+              ]
+            },
+            {
+              "name": "--issuer",
+              "usage": [
+                "--issuer <ISSUER>"
+              ],
+              "tip": [
+                "与要重置或显示的签名密钥关联的颁发者。默认为 'dotnet-user-jwts'。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--output",
+              "alias": [
+                "-o"
+              ],
+              "usage": [
+                "-o, --output <FORMAT>"
+              ],
+              "tip": [
+                "用于显示命令输出内容的格式。可以是 'default'、'token' 或 'json'。"
+              ],
+              "next": [
+                {
+                  "name": "default"
+                },
+                {
+                  "name": "json"
+                },
+                {
+                  "name": "token"
+                }
+              ]
+            },
+            {
+              "name": "--project",
+              "alias": [
+                "-p"
+              ],
+              "usage": [
+                "-p, --project <PROJECT>"
+              ],
+              "tip": [
+                "要操作的项目路径。默认为当前目录中的项目。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--reset",
+              "tip": [
+                "重置签名密钥。这将使为此项目发布的所有先前 JWT 失效。"
+              ]
+            },
+            {
+              "name": "--scheme",
+              "usage": [
+                "--scheme <SCHEME>"
+              ],
+              "tip": [
+                "与要重置或显示的签名密钥关联的方案名称。默认为 'Bearer'。"
+              ],
+              "next": []
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "tip": [
+            "列出为该 JWT 项目发布的令牌。"
+          ],
+          "option": [
+            {
+              "name": "--output",
+              "alias": [
+                "-o"
+              ],
+              "usage": [
+                "-o, --output <FORMAT>"
+              ],
+              "tip": [
+                "用于显示命令输出内容的格式。可以是 'default'、'token' 或 'json'。"
+              ],
+              "next": [
+                {
+                  "name": "default"
+                },
+                {
+                  "name": "json"
+                },
+                {
+                  "name": "token"
+                }
+              ]
+            },
+            {
+              "name": "--project",
+              "alias": [
+                "-p"
+              ],
+              "usage": [
+                "-p, --project <PROJECT>"
+              ],
+              "tip": [
+                "要操作的项目路径。默认为当前目录中的项目。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--show-tokens",
+              "tip": [
+                "指示是否应显示 JWT base64 字符串。"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "print",
+          "usage": [
+            "print [<ID>]"
+          ],
+          "tip": [
+            "打印给定 JWT 的详细信息。"
+          ],
+          "option": [
+            {
+              "name": "--output",
+              "alias": [
+                "-o"
+              ],
+              "usage": [
+                "-o, --output <FORMAT>"
+              ],
+              "tip": [
+                "用于显示命令输出内容的格式。可以是 'default'、'token' 或 'json'。"
+              ],
+              "next": [
+                {
+                  "name": "default"
+                },
+                {
+                  "name": "json"
+                },
+                {
+                  "name": "token"
+                }
+              ]
+            },
+            {
+              "name": "--project",
+              "alias": [
+                "-p"
+              ],
+              "usage": [
+                "-p, --project <PROJECT>"
+              ],
+              "tip": [
+                "要操作的项目路径。默认为当前目录中的项目。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--show-all",
+              "tip": [
+                "是否显示与 JWT 关联的所有详细信息。"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "remove",
+          "usage": [
+            "remove [<ID>]"
+          ],
+          "tip": [
+            "移除给定的 JWT。"
+          ],
+          "option": [
+            {
+              "name": "--appsettings-file",
+              "usage": [
+                "--appsettings-file <FILE>"
+              ],
+              "tip": [
+                "要添加测试方案的 appSettings 配置文件。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--output",
+              "alias": [
+                "-o"
+              ],
+              "usage": [
+                "-o, --output <FORMAT>"
+              ],
+              "tip": [
+                "用于显示命令输出内容的格式。可以是 'default'、'token' 或 'json'。"
+              ],
+              "next": [
+                {
+                  "name": "default"
+                },
+                {
+                  "name": "json"
+                },
+                {
+                  "name": "token"
+                }
+              ]
+            },
+            {
+              "name": "--project",
+              "alias": [
+                "-p"
+              ],
+              "usage": [
+                "-p, --project <PROJECT>"
+              ],
+              "tip": [
+                "要操作的项目路径。默认为当前目录中的项目。"
+              ],
+              "next": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "user-secrets",
+      "tip": [
+        "管理开发用户密码。"
+      ],
+      "option": [
+        {
+          "name": "--configuration",
+          "alias": [
+            "-c"
+          ],
+          "usage": [
+            "-c, --configuration <CONFIGURATION>"
+          ],
+          "tip": [
+            "要使用的项目配置。默认为 'Debug'。"
+          ],
+          "next": [
+            {
+              "name": "Debug"
+            },
+            {
+              "name": "Release"
+            }
+          ]
+        },
+        {
+          "name": "--file",
+          "alias": [
+            "-f"
+          ],
+          "usage": [
+            "-f, --file <FILE>"
+          ],
+          "tip": [
+            "文件型应用的路径。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--id",
+          "usage": [
+            "--id <USER_SECRET_ID>"
+          ],
+          "tip": [
+            "要使用的用户密码 ID。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--project",
+          "alias": [
+            "-p"
+          ],
+          "usage": [
+            "-p, --project <PROJECT>"
+          ],
+          "tip": [
+            "项目路径。默认为搜索当前目录。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--verbose",
+          "alias": [
+            "-v"
+          ],
+          "usage": [
+            "-v, --verbose"
+          ],
+          "tip": [
+            "显示详细输出。"
+          ]
+        },
+        {
+          "name": "--version",
+          "tip": [
+            "显示版本信息。"
+          ]
+        }
+      ],
+      "next": [
+        {
+          "name": "clear",
+          "tip": [
+            "删除所有应用程序密码。"
+          ],
+          "option": [
+            {
+              "name": "--configuration",
+              "alias": [
+                "-c"
+              ],
+              "usage": [
+                "-c, --configuration <CONFIGURATION>"
+              ],
+              "tip": [
+                "要使用的项目配置。默认为 'Debug'。"
+              ],
+              "next": [
+                {
+                  "name": "Debug"
+                },
+                {
+                  "name": "Release"
+                }
+              ]
+            },
+            {
+              "name": "--file",
+              "alias": [
+                "-f"
+              ],
+              "usage": [
+                "-f, --file <FILE>"
+              ],
+              "tip": [
+                "文件型应用的路径。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--id",
+              "usage": [
+                "--id <USER_SECRET_ID>"
+              ],
+              "tip": [
+                "要使用的用户密码 ID。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--project",
+              "alias": [
+                "-p"
+              ],
+              "usage": [
+                "-p, --project <PROJECT>"
+              ],
+              "tip": [
+                "项目路径。默认为搜索当前目录。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbose",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbose"
+              ],
+              "tip": [
+                "显示详细输出。"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "init",
+          "tip": [
+            "设置用户密码 ID 以启用密码存储。"
+          ],
+          "option": [
+            {
+              "name": "--configuration",
+              "alias": [
+                "-c"
+              ],
+              "usage": [
+                "-c, --configuration <CONFIGURATION>"
+              ],
+              "tip": [
+                "要使用的项目配置。默认为 'Debug'。"
+              ],
+              "next": [
+                {
+                  "name": "Debug"
+                },
+                {
+                  "name": "Release"
+                }
+              ]
+            },
+            {
+              "name": "--file",
+              "alias": [
+                "-f"
+              ],
+              "usage": [
+                "-f, --file <FILE>"
+              ],
+              "tip": [
+                "文件型应用的路径。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--id",
+              "usage": [
+                "--id <USER_SECRET_ID>"
+              ],
+              "tip": [
+                "要使用的用户密码 ID。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--project",
+              "alias": [
+                "-p"
+              ],
+              "usage": [
+                "-p, --project <PROJECT>"
+              ],
+              "tip": [
+                "项目路径。默认为搜索当前目录。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbose",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbose"
+              ],
+              "tip": [
+                "显示详细输出。"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "tip": [
+            "列出所有应用程序密码。"
+          ],
+          "option": [
+            {
+              "name": "--configuration",
+              "alias": [
+                "-c"
+              ],
+              "usage": [
+                "-c, --configuration <CONFIGURATION>"
+              ],
+              "tip": [
+                "要使用的项目配置。默认为 'Debug'。"
+              ],
+              "next": [
+                {
+                  "name": "Debug"
+                },
+                {
+                  "name": "Release"
+                }
+              ]
+            },
+            {
+              "name": "--file",
+              "alias": [
+                "-f"
+              ],
+              "usage": [
+                "-f, --file <FILE>"
+              ],
+              "tip": [
+                "文件型应用的路径。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--id",
+              "usage": [
+                "--id <USER_SECRET_ID>"
+              ],
+              "tip": [
+                "要使用的用户密码 ID。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--json",
+              "tip": [
+                "使用 json 输出。JSON 由 '//BEGIN' 和 '//END' 包装。"
+              ]
+            },
+            {
+              "name": "--project",
+              "alias": [
+                "-p"
+              ],
+              "usage": [
+                "-p, --project <PROJECT>"
+              ],
+              "tip": [
+                "项目路径。默认为搜索当前目录。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbose",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbose"
+              ],
+              "tip": [
+                "显示详细输出。"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "remove",
+          "usage": [
+            "remove [<NAME>]"
+          ],
+          "tip": [
+            "移除指定的用户密码。"
+          ],
+          "option": [
+            {
+              "name": "--configuration",
+              "alias": [
+                "-c"
+              ],
+              "usage": [
+                "-c, --configuration <CONFIGURATION>"
+              ],
+              "tip": [
+                "要使用的项目配置。默认为 'Debug'。"
+              ],
+              "next": [
+                {
+                  "name": "Debug"
+                },
+                {
+                  "name": "Release"
+                }
+              ]
+            },
+            {
+              "name": "--file",
+              "alias": [
+                "-f"
+              ],
+              "usage": [
+                "-f, --file <FILE>"
+              ],
+              "tip": [
+                "文件型应用的路径。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--id",
+              "usage": [
+                "--id <USER_SECRET_ID>"
+              ],
+              "tip": [
+                "要使用的用户密码 ID。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--project",
+              "alias": [
+                "-p"
+              ],
+              "usage": [
+                "-p, --project <PROJECT>"
+              ],
+              "tip": [
+                "项目路径。默认为搜索当前目录。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbose",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbose"
+              ],
+              "tip": [
+                "显示详细输出。"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "set",
+          "usage": [
+            "set <NAME> <VALUE>"
+          ],
+          "tip": [
+            "将用户密码设置为指定值。"
+          ],
+          "option": [
+            {
+              "name": "--configuration",
+              "alias": [
+                "-c"
+              ],
+              "usage": [
+                "-c, --configuration <CONFIGURATION>"
+              ],
+              "tip": [
+                "要使用的项目配置。默认为 'Debug'。"
+              ],
+              "next": [
+                {
+                  "name": "Debug"
+                },
+                {
+                  "name": "Release"
+                }
+              ]
+            },
+            {
+              "name": "--file",
+              "alias": [
+                "-f"
+              ],
+              "usage": [
+                "-f, --file <FILE>"
+              ],
+              "tip": [
+                "文件型应用的路径。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--id",
+              "usage": [
+                "--id <USER_SECRET_ID>"
+              ],
+              "tip": [
+                "要使用的用户密码 ID。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--project",
+              "alias": [
+                "-p"
+              ],
+              "usage": [
+                "-p, --project <PROJECT>"
+              ],
+              "tip": [
+                "项目路径。默认为搜索当前目录。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbose",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbose"
+              ],
+              "tip": [
+                "显示详细输出。"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "vstest",
+      "tip": [
+        "运行 Microsoft 测试引擎（VSTest）命令。"
+      ],
+      "option": [
+        {
+          "name": "--Blame",
+          "usage": [
+            "--Blame [COLLECTDUMP]"
+          ],
+          "tip": [
+            "在 blame 模式下运行测试。此选项有助于隔离导致测试主机崩溃的可疑测试。"
+          ],
+          "next": [
+            {
+              "name": "CollectDump",
+              "tip": [
+                "为测试主机收集进程转储"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--Collect",
+          "usage": [
+            "--Collect <DATA_COLLECTOR_NAME>"
+          ],
+          "tip": [
+            "为测试运行启用数据收集器。"
+          ],
+          "next": [
+            {
+              "name": "\"Code Coverage\"",
+              "tip": [
+                "代码覆盖率数据收集器"
+              ]
+            },
+            {
+              "name": "\"XPlat Code Coverage\"",
+              "tip": [
+                "跨平台代码覆盖率数据收集器"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--Diag",
+          "usage": [
+            "--Diag <LOG_FILE>"
+          ],
+          "tip": [
+            "为测试平台启用日志。日志写入提供的文件中。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--Environment",
+          "alias": [
+            "-e"
+          ],
+          "usage": [
+            "-e, --Environment <NAME=VALUE>"
+          ],
+          "tip": [
+            "设置环境变量的值。如果变量不存在则创建，如果存在则覆盖。",
+            "可以多次指定此参数以提供多个变量。"
+          ],
+          "repeat": 99,
+          "next": []
+        },
+        {
+          "name": "--Framework",
+          "usage": [
+            "--Framework <FRAMEWORK_VERSION>"
+          ],
+          "tip": [
+            "用于测试执行的目标 .NET Framework 版本。"
+          ],
+          "next": [
+            {
+              "name": ".NETCoreApp,Version=v10.0",
+              "tip": [
+                ".NET Core 10.0 "
+              ]
+            },
+            {
+              "name": ".NETCoreApp,Version=v8.0",
+              "tip": [
+                ".NET Core 8.0 "
+              ]
+            },
+            {
+              "name": ".NETFramework,Version=v4.5.1",
+              "tip": [
+                ".NET Framework 4.5.1 "
+              ]
+            },
+            {
+              "name": ".NETFramework,Version=v4.8",
+              "tip": [
+                ".NET Framework 4.8 "
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--InIsolation",
+          "tip": [
+            "在隔离进程中运行测试。这使 vstest.console.exe 进程不太可能因测试中的错误而停止。"
+          ]
+        },
+        {
+          "name": "--ListTests",
+          "alias": [
+            "-lt"
+          ],
+          "usage": [
+            "-lt, --ListTests <FILE_NAME>"
+          ],
+          "tip": [
+            "列出给定测试容器中发现的所有测试。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--logger",
+          "usage": [
+            "--logger <LOGGER_URI|FRIENDLYNAME>"
+          ],
+          "tip": [
+            "为测试结果指定记录器。例如，要记录到 Visual Studio 测试结果文件（TRX），请使用 --logger trx。"
+          ],
+          "next": [
+            {
+              "name": "console",
+              "tip": [
+                "控制台记录器"
+              ]
+            },
+            {
+              "name": "trx",
+              "tip": [
+                "TRX 文件记录器"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--Parallel",
+          "tip": [
+            "指定测试应并行执行。默认情况下可使用计算机上最多所有可用内核。"
+          ]
+        },
+        {
+          "name": "--Platform",
+          "usage": [
+            "--Platform <PLATFORM_TYPE>"
+          ],
+          "tip": [
+            "用于测试执行的目标平台体系结构。有效值为 x86、x64 和 ARM。"
+          ],
+          "next": [
+            {
+              "name": "ARM"
+            },
+            {
+              "name": "x64"
+            },
+            {
+              "name": "x86"
+            }
+          ]
+        },
+        {
+          "name": "--ResultsDirectory",
+          "usage": [
+            "--ResultsDirectory <PATH>"
+          ],
+          "tip": [
+            "如果测试结果目录不存在，将在指定路径中创建。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--Settings",
+          "usage": [
+            "--Settings <SETTINGS_FILE>"
+          ],
+          "tip": [
+            "运行测试时使用的设置。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--TestAdapterLoadingStrategy",
+          "usage": [
+            "--TestAdapterLoadingStrategy <STRATEGY>"
+          ],
+          "tip": [
+            "这会影响适配器加载行为。当前支持的行为：Explicit、Default、DefaultRuntimeProviders、ExtensionsDirectory、NextToSource 和 Recursive。"
+          ],
+          "next": [
+            {
+              "name": "Default"
+            },
+            {
+              "name": "DefaultRuntimeProviders"
+            },
+            {
+              "name": "Explicit"
+            },
+            {
+              "name": "ExtensionsDirectory"
+            },
+            {
+              "name": "NextToSource"
+            },
+            {
+              "name": "Recursive"
+            }
+          ]
+        },
+        {
+          "name": "--TestAdapterPath",
+          "usage": [
+            "--TestAdapterPath <PATH>"
+          ],
+          "tip": [
+            "使 vstest.console.exe 进程在测试运行中使用给定路径（如果有）的自定义测试适配器。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--TestCaseFilter",
+          "usage": [
+            "--TestCaseFilter <EXPRESSION>"
+          ],
+          "tip": [
+            "运行与给定表达式匹配的测试。<Expression> 的格式为 <property>Operator<value>[|&<Expression>]。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--Tests",
+          "usage": [
+            "--Tests <TEST_NAMES>"
+          ],
+          "tip": [
+            "运行名称与提供的值匹配的测试。要提供多个值，请用逗号分隔。"
+          ],
+          "next": []
+        }
+      ]
+    },
+    {
+      "name": "watch",
+      "tip": [
+        "启动文件观察程序，它会在文件发生更改时运行命令。"
+      ],
+      "option": [
+        {
+          "name": "--arch",
+          "alias": [
+            "-a"
+          ],
+          "usage": [
+            "-a, --arch <ARCH>"
+          ],
+          "tip": [
+            "目标体系结构。"
+          ],
+          "next": [
+            {
+              "name": "arm64",
+              "tip": [
+                "ARM64 "
+              ]
+            },
+            {
+              "name": "x64",
+              "tip": [
+                "64 位 x86"
+              ]
+            },
+            {
+              "name": "x86",
+              "tip": [
+                "32 位 x86"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--artifacts-path",
+          "usage": [
+            "--artifacts-path <ARTIFACTS_DIR>"
+          ],
+          "tip": [
+            "产物路径。项目的所有输出（包括生成、发布和打包输出）都将放到指定路径下的子文件夹中。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--configuration",
+          "alias": [
+            "-c"
+          ],
+          "usage": [
+            "-c, --configuration <CONFIGURATION>"
+          ],
+          "tip": [
+            "要运行的配置。大多数项目的默认值是 \"Debug\"。"
+          ],
+          "next": [
+            {
+              "name": "Debug"
+            },
+            {
+              "name": "Release"
+            }
+          ]
+        },
+        {
+          "name": "--device",
+          "usage": [
+            "--device <DEVICE_ID>"
+          ],
+          "tip": [
+            "要在其上运行的设备标识符（例如模拟器、模拟器或物理设备）。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--disable-build-servers",
+          "tip": [
+            "强制命令忽略任何永久性生成服务器。"
+          ]
+        },
+        {
+          "name": "--file",
+          "usage": [
+            "--file <FILE_PATH>"
+          ],
+          "tip": [
+            "要运行的文件型应用的路径（如果当前目录中没有项目，也可以作为第一个参数传递）。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--framework",
+          "alias": [
+            "-f"
+          ],
+          "usage": [
+            "-f, --framework <FRAMEWORK>"
+          ],
+          "tip": [
+            "要为其生成的目标框架。必须在项目文件中指定目标框架。"
+          ],
+          "next": [
+            {
+              "name": "net10.0",
+              "tip": [
+                ".NET 10 "
+              ]
+            },
+            {
+              "name": "net8.0",
+              "tip": [
+                ".NET 8 "
+              ]
+            },
+            {
+              "name": "net9.0",
+              "tip": [
+                ".NET 9 "
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--interactive",
+          "tip": [
+            "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+          ]
+        },
+        {
+          "name": "--launch-profile",
+          "alias": [
+            "-lp"
+          ],
+          "usage": [
+            "-lp, --launch-profile <LAUNCH_PROFILE>"
+          ],
+          "tip": [
+            "启动应用程序时使用的启动配置文件名称（如果有）。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--list",
+          "tip": [
+            "列出所有发现的文件，而不启动观察程序。"
+          ]
+        },
+        {
+          "name": "--no-hot-reload",
+          "tip": [
+            "抑制支持的热重载。"
+          ]
+        },
+        {
+          "name": "--no-launch-profile",
+          "tip": [
+            "不要尝试使用 launchSettings.json 或 [app].run.json 来配置应用程序。"
+          ]
+        },
+        {
+          "name": "--no-restore",
+          "tip": [
+            "生成前不还原项目。"
+          ]
+        },
+        {
+          "name": "--no-self-contained",
+          "tip": [
+            "将应用程序发布为依赖框架的应用程序。目标计算机上必须安装兼容的 .NET 运行时才能运行该应用程序。"
+          ]
+        },
+        {
+          "name": "--non-interactive",
+          "tip": [
+            "在非交互模式下运行 dotnet-watch。仅在启用热重载运行时支持此选项。"
+          ]
+        },
+        {
+          "name": "--os",
+          "usage": [
+            "--os <OS>"
+          ],
+          "tip": [
+            "目标操作系统。"
+          ],
+          "next": [
+            {
+              "name": "linux",
+              "tip": [
+                "Linux "
+              ]
+            },
+            {
+              "name": "osx",
+              "tip": [
+                "macOS "
+              ]
+            },
+            {
+              "name": "win",
+              "tip": [
+                "Windows "
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--project",
+          "usage": [
+            "--project <PROJECT_PATH>"
+          ],
+          "tip": [
+            "定义要运行的项目文件的路径。如果未指定，默认为当前目录。"
+          ],
+          "next": []
+        },
+        {
+          "name": "--quiet",
+          "alias": [
+            "-q"
+          ],
+          "usage": [
+            "-q, --quiet"
+          ],
+          "tip": [
+            "抑制所有输出（警告和错误除外）。"
+          ]
+        },
+        {
+          "name": "--runtime",
+          "alias": [
+            "-r"
+          ],
+          "usage": [
+            "-r, --runtime <RUNTIME_IDENTIFIER>"
+          ],
+          "tip": [
+            "要为其运行的目标运行时。"
+          ],
+          "next": [
+            {
+              "name": "linux-x64",
+              "tip": [
+                "Linux x64 "
+              ]
+            },
+            {
+              "name": "osx-arm64",
+              "tip": [
+                "macOS ARM64 "
+              ]
+            },
+            {
+              "name": "win-x64",
+              "tip": [
+                "Windows x64 "
+              ]
+            }
+          ]
+        },
+        {
+          "name": "--self-contained",
+          "alias": [
+            "--sc"
+          ],
+          "usage": [
+            "--sc, --self-contained"
+          ],
+          "tip": [
+            "随应用程序发布 .NET 运行时，这样无需在目标计算机上安装运行时。",
+            "默认值为 'false'。但在面向 .NET 7 或更低版本时，如果指定了运行时标识符，默认值为 'true'。"
+          ]
+        },
+        {
+          "name": "--verbose",
+          "tip": [
+            "显示详细输出。"
+          ]
+        },
+        {
+          "name": "--verbosity",
+          "alias": [
+            "-verbosity",
+            "-v"
+          ],
+          "usage": [
+            "-v, -verbosity, --verbosity <LEVEL>"
+          ],
+          "tip": [
+            "设置 MSBuild 详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。"
+          ],
+          "next": [
+            {
+              "name": "detailed"
+            },
+            {
+              "name": "diagnostic"
+            },
+            {
+              "name": "minimal"
+            },
+            {
+              "name": "normal"
+            },
+            {
+              "name": "quiet"
+            }
+          ]
+        },
+        {
+          "name": "--version",
+          "tip": [
+            "显示版本信息。"
           ]
         }
       ]
@@ -404,67 +8618,636 @@
     {
       "name": "workload",
       "tip": [
-        "安装或使用扩展 .NET 体验的工作负载。"
+        "管理可选工作负载。"
+      ],
+      "option": [
+        {
+          "name": "--info",
+          "tip": [
+            "显示已安装工作负载的信息。"
+          ]
+        },
+        {
+          "name": "--version",
+          "tip": [
+            "显示当前安装的工作负载版本。"
+          ]
+        }
       ],
       "next": [
         {
           "name": "clean",
           "tip": [
-            "移除工作负载组件。"
+            "移除先前更新和卸载可能留下的工作负载组件。"
+          ],
+          "option": [
+            {
+              "name": "--all",
+              "tip": [
+                "使 clean 从所有 SDK 版本中移除并卸载所有工作负载组件。"
+              ]
+            }
           ]
         },
         {
           "name": "config",
           "tip": [
-            "启用或禁用工作负载集更新模式。"
+            "修改或显示工作负载配置值。",
+            "要显示值，请指定相应的命令行选项而不提供值。例如：\"dotnet workload config --update-mode\"。"
+          ],
+          "option": [
+            {
+              "name": "--update-mode",
+              "usage": [
+                "--update-mode <MANIFESTS|WORKLOAD_SET>"
+              ],
+              "tip": [
+                "控制更新应查找工作负载集还是每个单独清单的最新版本。"
+              ],
+              "next": [
+                {
+                  "name": "manifests"
+                },
+                {
+                  "name": "workload-set"
+                }
+              ]
+            }
           ]
         },
         {
           "name": "history",
           "tip": [
-            "显示所有工作负载安装操作。"
+            "显示工作负载安装操作的历史记录。"
           ]
         },
         {
           "name": "install",
+          "usage": [
+            "install <WORKLOAD_ID>"
+          ],
           "tip": [
-            "安装可选工作负载。"
+            "安装一个或多个工作负载。"
+          ],
+          "option": [
+            {
+              "name": "--configfile",
+              "usage": [
+                "--configfile <FILE>"
+              ],
+              "tip": [
+                "要使用的 NuGet 配置文件。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--disable-parallel",
+              "tip": [
+                "阻止并行还原多个项目。"
+              ]
+            },
+            {
+              "name": "--ignore-failed-sources",
+              "tip": [
+                "将包源失败视为警告。"
+              ]
+            },
+            {
+              "name": "--include-previews",
+              "tip": [
+                "允许预发布工作负载清单。"
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+              ]
+            },
+            {
+              "name": "--no-http-cache",
+              "tip": [
+                "不缓存包和 http 请求。"
+              ]
+            },
+            {
+              "name": "--skip-manifest-update",
+              "tip": [
+                "跳过更新工作负载清单。"
+              ]
+            },
+            {
+              "name": "--source",
+              "alias": [
+                "-s"
+              ],
+              "usage": [
+                "-s, --source <SOURCE>"
+              ],
+              "tip": [
+                "还原期间使用的 NuGet 包源。要指定多个源，请重复该选项。"
+              ],
+              "repeat": 99,
+              "next": []
+            },
+            {
+              "name": "--temp-dir",
+              "usage": [
+                "--temp-dir <TEMP_DIR>"
+              ],
+              "tip": [
+                "为此命令指定一个临时目录，用于下载和提取 NuGet 包（必须安全）。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "设置 MSBuild 详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。[默认值: normal]"
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            },
+            {
+              "name": "--version",
+              "usage": [
+                "--version <VERSION>"
+              ],
+              "tip": [
+                "要显示的工作负载版本，或一个或多个工作负载及其以 '@' 字符连接的版本。"
+              ],
+              "next": []
+            }
           ]
         },
         {
           "name": "list",
           "tip": [
-            "列出所有已安装的工作负载。"
+            "列出可用的工作负载。"
           ]
         },
         {
           "name": "repair",
           "tip": [
-            "修复所有已安装的工作负载。"
+            "修复工作负载安装。"
+          ],
+          "option": [
+            {
+              "name": "--configfile",
+              "usage": [
+                "--configfile <FILE>"
+              ],
+              "tip": [
+                "要使用的 NuGet 配置文件。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--disable-parallel",
+              "tip": [
+                "阻止并行还原多个项目。"
+              ]
+            },
+            {
+              "name": "--ignore-failed-sources",
+              "tip": [
+                "将包源失败视为警告。"
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+              ]
+            },
+            {
+              "name": "--no-http-cache",
+              "tip": [
+                "不缓存包和 http 请求。"
+              ]
+            },
+            {
+              "name": "--source",
+              "alias": [
+                "-s"
+              ],
+              "usage": [
+                "-s, --source <SOURCE>"
+              ],
+              "tip": [
+                "还原期间使用的 NuGet 包源。要指定多个源，请重复该选项。"
+              ],
+              "repeat": 99,
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "设置 MSBuild 详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。[默认值: normal]"
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
           ]
         },
         {
           "name": "restore",
+          "usage": [
+            "restore [<PROJECT | SOLUTION>]"
+          ],
           "tip": [
             "还原项目所需的工作负载。"
+          ],
+          "option": [
+            {
+              "name": "--configfile",
+              "usage": [
+                "--configfile <FILE>"
+              ],
+              "tip": [
+                "要使用的 NuGet 配置文件。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--disable-parallel",
+              "tip": [
+                "阻止并行还原多个项目。"
+              ]
+            },
+            {
+              "name": "--ignore-failed-sources",
+              "tip": [
+                "将包源失败视为警告。"
+              ]
+            },
+            {
+              "name": "--include-previews",
+              "tip": [
+                "允许预发布工作负载清单。"
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+              ]
+            },
+            {
+              "name": "--no-http-cache",
+              "tip": [
+                "不缓存包和 http 请求。"
+              ]
+            },
+            {
+              "name": "--skip-manifest-update",
+              "tip": [
+                "跳过更新工作负载清单。"
+              ]
+            },
+            {
+              "name": "--source",
+              "alias": [
+                "-s"
+              ],
+              "usage": [
+                "-s, --source <SOURCE>"
+              ],
+              "tip": [
+                "还原期间使用的 NuGet 包源。要指定多个源，请重复该选项。"
+              ],
+              "repeat": 99,
+              "next": []
+            },
+            {
+              "name": "--temp-dir",
+              "usage": [
+                "--temp-dir <TEMP_DIR>"
+              ],
+              "tip": [
+                "为此命令指定一个临时目录，用于下载和提取 NuGet 包（必须安全）。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "设置 MSBuild 详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。[默认值: normal]"
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            },
+            {
+              "name": "--version",
+              "usage": [
+                "--version <VERSION>"
+              ],
+              "tip": [
+                "要显示的工作负载版本，或一个或多个工作负载及其以 '@' 字符连接的版本。"
+              ],
+              "next": []
+            }
           ]
         },
         {
           "name": "search",
+          "usage": [
+            "search [<SEARCH_STRING>]"
+          ],
           "tip": [
-            "列出选定的工作负载或所有可用的工作负载。"
+            "搜索可用的工作负载。"
+          ],
+          "next": [
+            {
+              "name": "version",
+              "usage": [
+                "version [<WORKLOAD_VERSION>]"
+              ],
+              "tip": [
+                "搜索可用的工作负载版本或工作负载版本的组成。"
+              ],
+              "option": [
+                {
+                  "name": "--format",
+                  "usage": [
+                    "--format <JSON|LIST>"
+                  ],
+                  "tip": [
+                    "更改输出的工作负载版本的格式。可以取 'json' 或 'list'。"
+                  ],
+                  "next": [
+                    {
+                      "name": "json"
+                    },
+                    {
+                      "name": "list"
+                    }
+                  ]
+                },
+                {
+                  "name": "--include-previews",
+                  "tip": [
+                    "包含预览版本。"
+                  ]
+                },
+                {
+                  "name": "--take",
+                  "usage": [
+                    "--take <TAKE>"
+                  ],
+                  "tip": [
+                    "要提供的结果数。[默认值: 5]"
+                  ],
+                  "next": []
+                }
+              ]
+            }
           ]
         },
         {
           "name": "uninstall",
+          "usage": [
+            "uninstall <WORKLOAD_ID>"
+          ],
           "tip": [
-            "卸载工作负载。"
+            "卸载一个或多个工作负载。"
+          ],
+          "option": [
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "设置 MSBuild 详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。[默认值: normal]"
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            }
           ]
         },
         {
           "name": "update",
           "tip": [
-            "重新安装所有已安装的工作负载。"
+            "更新所有已安装的工作负载。"
+          ],
+          "option": [
+            {
+              "name": "--advertising-manifests-only",
+              "tip": [
+                "仅更新公告清单。"
+              ]
+            },
+            {
+              "name": "--configfile",
+              "usage": [
+                "--configfile <FILE>"
+              ],
+              "tip": [
+                "要使用的 NuGet 配置文件。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--disable-parallel",
+              "tip": [
+                "阻止并行还原多个项目。"
+              ]
+            },
+            {
+              "name": "--from-history",
+              "usage": [
+                "--from-history <VERSION>"
+              ],
+              "tip": [
+                "将工作负载更新到参数指定的先前版本。使用 'dotnet workload history' 查看可用的工作负载历史记录。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--from-previous-sdk",
+              "tip": [
+                "在更新中包括使用早期 SDK 版本安装的工作负载。"
+              ]
+            },
+            {
+              "name": "--ignore-failed-sources",
+              "tip": [
+                "将包源失败视为警告。"
+              ]
+            },
+            {
+              "name": "--include-previews",
+              "tip": [
+                "允许预发布工作负载清单。"
+              ]
+            },
+            {
+              "name": "--interactive",
+              "tip": [
+                "允许命令停止并等待用户输入或操作（例如完成身份验证）。"
+              ]
+            },
+            {
+              "name": "--manifests-only",
+              "usage": [
+                "--manifests-only <VERSION>"
+              ],
+              "tip": [
+                "更新到历史记录中指定的工作负载版本，而不更改已安装的工作负载。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--no-http-cache",
+              "tip": [
+                "不缓存包和 http 请求。"
+              ]
+            },
+            {
+              "name": "--source",
+              "alias": [
+                "-s"
+              ],
+              "usage": [
+                "-s, --source <SOURCE>"
+              ],
+              "tip": [
+                "还原期间使用的 NuGet 包源。要指定多个源，请重复该选项。"
+              ],
+              "repeat": 99,
+              "next": []
+            },
+            {
+              "name": "--temp-dir",
+              "usage": [
+                "--temp-dir <TEMP_DIR>"
+              ],
+              "tip": [
+                "为此命令指定一个临时目录，用于下载和提取 NuGet 包（必须安全）。"
+              ],
+              "next": []
+            },
+            {
+              "name": "--verbosity",
+              "alias": [
+                "-v"
+              ],
+              "usage": [
+                "-v, --verbosity <LEVEL>"
+              ],
+              "tip": [
+                "设置 MSBuild 详细级别。允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。[默认值: normal]"
+              ],
+              "next": [
+                {
+                  "name": "detailed"
+                },
+                {
+                  "name": "diagnostic"
+                },
+                {
+                  "name": "minimal"
+                },
+                {
+                  "name": "normal"
+                },
+                {
+                  "name": "quiet"
+                }
+              ]
+            },
+            {
+              "name": "--version",
+              "usage": [
+                "--version <VERSION>"
+              ],
+              "tip": [
+                "要显示的工作负载版本，或一个或多个工作负载及其以 '@' 字符连接的版本。"
+              ],
+              "next": []
+            }
           ]
         }
       ]
@@ -474,45 +9257,51 @@
     {
       "name": "--info",
       "tip": [
-        "打印出有关 .NET 安装和机器环境的详细信息，",
-        "例如当前操作系统以及 .NET 版本的提交 SHA。"
+        "显示 .NET 信息。"
       ]
     },
     {
       "name": "--list-runtimes",
       "tip": [
-        "打印出针对所调用的 dotnet 架构已安装的 .NET 运行时列表。"
+        "显示已安装的运行时。"
       ]
     },
     {
       "name": "--list-sdks",
       "tip": [
-        "打印出针对所调用的 dotnet 架构已安装的 .NET SDK 列表。"
+        "显示已安装的 SDK。"
       ]
     },
     {
       "name": "--version",
       "tip": [
-        "打印出 dotnet 命令所使用的 .NET SDK 版本。",
-        "它可能会受到 global.json 文件的影响。",
-        "仅在安装了 SDK 时可用。"
+        "显示使用中的 .NET SDK 版本。"
       ]
     }
   ],
   "global_option": [
     {
       "name": "--additional-deps",
+      "usage": [
+        "--additional-deps <PATH>"
+      ],
       "tip": [
-        "附加 .deps.json 文件的路径。",
+        "附加 deps.json 文件的路径。",
         "deps.json 文件包含依赖项列表、编译依赖项以及用于解决程序集冲突的版本信息。"
-      ]
+      ],
+      "next": []
     },
     {
       "name": "--additionalprobingpath",
+      "usage": [
+        "--additionalprobingpath <PATH>"
+      ],
       "tip": [
         "包含探测策略和待探测程序集的路径。",
         "重复该选项以指定多个路径。"
-      ]
+      ],
+      "repeat": 99,
+      "next": []
     },
     {
       "name": "--diagnostics",
@@ -528,9 +9317,13 @@
     },
     {
       "name": "--fx-version",
+      "usage": [
+        "--fx-version <VERSION>"
+      ],
       "tip": [
-        "用于运行应用程序的 .NET 运行时版本。"
-      ]
+        "用于运行应用程序的已安装共享框架的版本。"
+      ],
+      "next": []
     },
     {
       "name": "--help",
@@ -542,7 +9335,7 @@
         "-?, -h, --help"
       ],
       "tip": [
-        "打印出给定命令的文档。"
+        "显示命令行帮助。"
       ]
     },
     {
@@ -551,10 +9344,8 @@
         "--roll-forward <SETTING>"
       ],
       "tip": [
-        "控制前滚如何应用于应用程序。",
-        "SETTING 可以是以下值之一。",
-        "如果未指定，默认值为 Minor。",
-        "[LatestPatch|Minor|Major|LatestMinor|LatestMajor|Disable]"
+        "前滚至框架版本（LatestPatch、Minor、LatestMinor、Major、LatestMajor、Disable）。",
+        "如果未指定，默认值为 Minor。"
       ],
       "next": [
         {
@@ -583,12 +9374,29 @@
         "-v"
       ],
       "usage": [
-        "-v, --verbosity"
+        "-v, --verbosity <LEVEL>"
       ],
       "tip": [
         "设置命令的详细级别。",
-        "允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed]和 diag[nostic]。",
+        "允许的值为 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。",
         "并非所有命令都支持此选项。"
+      ],
+      "next": [
+        {
+          "name": "detailed"
+        },
+        {
+          "name": "diagnostic"
+        },
+        {
+          "name": "minimal"
+        },
+        {
+          "name": "normal"
+        },
+        {
+          "name": "quiet"
+        }
       ]
     }
   ]


### PR DESCRIPTION
- add format, vstest and bundled tools (dev-certs, fsi, user-jwts, user-secrets, watch)
- rename sln to solution, keep sln alias; add solution migrate
- add new create; nuget config/why/verify/sign/trust with source/client-cert groups; package update/download; tool run/restore/execute; workload search version; build-server shutdown
- expand options for build, clean, pack, publish, reference, restore, run, store, test, tool, workload, msbuild and vstest
- fix -no-update-check typo; add known candidate values via next
- hooks: solution targets, package update/download, new create, tool run (local tools); drop stale nuget add/remove package binding
- sync zh-CN translation (1411/1411)
